### PR TITLE
Debugger: Added option to reload ROM on Power Cycle

### DIFF
--- a/GUI.NET/Config/DebugInfo.cs
+++ b/GUI.NET/Config/DebugInfo.cs
@@ -339,6 +339,8 @@ namespace Mesen.GUI.Config
 		public bool RefreshWhileRunning = false;
 		public bool ShowMemoryValuesInCodeWindow = true;
 
+		public bool ReloadRomOnPowerCycle = false;
+
 		public bool BreakOnOpen = true;
 		public bool BreakOnReset = true;
 		public bool BreakOnUnofficialOpcodes = true;

--- a/GUI.NET/Debugger/frmDebugger.Designer.cs
+++ b/GUI.NET/Debugger/frmDebugger.Designer.cs
@@ -181,6 +181,8 @@ namespace Mesen.GUI.Debugger
 			this.mnuAlwaysScrollToCenter = new System.Windows.Forms.ToolStripMenuItem();
 			this.mnuRefreshWhileRunning = new System.Windows.Forms.ToolStripMenuItem();
 			this.toolStripMenuItem6 = new System.Windows.Forms.ToolStripSeparator();
+			this.mnuReloadRomOnPowerCycle = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
 			this.mnuConfigureExternalEditor = new System.Windows.Forms.ToolStripMenuItem();
 			this.mnuPreferences = new System.Windows.Forms.ToolStripMenuItem();
 			this.toolsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -1034,6 +1036,8 @@ namespace Mesen.GUI.Debugger
             this.mnuAlwaysScrollToCenter,
             this.mnuRefreshWhileRunning,
             this.toolStripMenuItem6,
+            this.mnuReloadRomOnPowerCycle,
+            this.toolStripSeparator2,
             this.mnuConfigureExternalEditor,
             this.mnuPreferences});
 			this.mnuOptions.Name = "mnuOptions";
@@ -1638,6 +1642,19 @@ namespace Mesen.GUI.Debugger
 			this.toolStripMenuItem6.Name = "toolStripMenuItem6";
 			this.toolStripMenuItem6.Size = new System.Drawing.Size(263, 6);
 			// 
+			// mnuReloadRomOnPowerCycle
+			// 
+			this.mnuReloadRomOnPowerCycle.CheckOnClick = true;
+			this.mnuReloadRomOnPowerCycle.Name = "mnuReloadRomOnPowerCycle";
+			this.mnuReloadRomOnPowerCycle.Size = new System.Drawing.Size(266, 22);
+			this.mnuReloadRomOnPowerCycle.Text = "Reload ROM on Power Cycle";
+			this.mnuReloadRomOnPowerCycle.Click += new System.EventHandler(this.mnuReloadRomOnPowerCycle_Click);
+			// 
+			// toolStripSeparator2
+			// 
+			this.toolStripSeparator2.Name = "toolStripSeparator2";
+			this.toolStripSeparator2.Size = new System.Drawing.Size(263, 6);
+			// 
 			// mnuConfigureExternalEditor
 			// 
 			this.mnuConfigureExternalEditor.Image = global::Mesen.GUI.Properties.Resources.Edit;
@@ -2236,5 +2253,7 @@ namespace Mesen.GUI.Debugger
 		private System.Windows.Forms.ToolStripMenuItem mnuBreakOnPpu2006ScrollGlitch;
 		private System.Windows.Forms.ToolStripMenuItem mnuBreakOnBusConflict;
 	  private System.Windows.Forms.ToolStripMenuItem mnuGoToAddress;
+	  private System.Windows.Forms.ToolStripMenuItem mnuReloadRomOnPowerCycle;
+	  private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
    }
 }

--- a/GUI.NET/Debugger/frmDebugger.cs
+++ b/GUI.NET/Debugger/frmDebugger.cs
@@ -130,6 +130,7 @@ namespace Mesen.GUI.Debugger
 			this.mnuShowSelectionLength.Checked = ConfigManager.Config.DebugInfo.ShowSelectionLength;
 			this.mnuAlwaysScrollToCenter.Checked = ConfigManager.Config.DebugInfo.AlwaysScrollToCenter;
 			this.mnuRefreshWhileRunning.Checked = ConfigManager.Config.DebugInfo.RefreshWhileRunning;
+			this.mnuReloadRomOnPowerCycle.Checked = ConfigManager.Config.DebugInfo.ReloadRomOnPowerCycle;
 			this.mnuShowMemoryValues.Checked = ConfigManager.Config.DebugInfo.ShowMemoryValuesInCodeWindow;
 			ctrlDebuggerCode.ShowMemoryValues = mnuShowMemoryValues.Checked;
 			ctrlDebuggerCodeSplit.ShowMemoryValues = mnuShowMemoryValues.Checked;
@@ -1271,6 +1272,12 @@ namespace Mesen.GUI.Debugger
 			ConfigManager.ApplyChanges();
 		}
 
+		private void mnuReloadRomOnPowerCycle_Click(object sender, EventArgs e)
+		{
+			ConfigManager.Config.DebugInfo.ReloadRomOnPowerCycle = mnuReloadRomOnPowerCycle.Checked;
+			ConfigManager.ApplyChanges();
+		}
+
 		private void mnuShowMemoryValues_Click(object sender, EventArgs e)
 		{
 			ConfigManager.Config.DebugInfo.ShowMemoryValuesInCodeWindow = mnuShowMemoryValues.Checked;
@@ -1684,7 +1691,11 @@ namespace Mesen.GUI.Debugger
 
 		private void mnuPowerCycle_Click(object sender, EventArgs e)
 		{
-			InteropEmu.PowerCycle();
+			if(ConfigManager.Config.DebugInfo.ReloadRomOnPowerCycle) {
+				InteropEmu.ReloadRom();
+			} else { 
+				InteropEmu.PowerCycle();
+			}
 		}
 
 		protected override void OnResize(EventArgs e)


### PR DESCRIPTION
Fixes: https://github.com/SourMesen/Mesen/issues/871

Added the option to reload ROM on Power Cycle in Debugger.

Reasoning: During development I rarely need to Power Cycle without pulling recently compiled/assembled changes.