### PR TITLE
HD Pack Builder and BGM tag improvement

### DIFF
--- a/Core/HdAudioDevice.cpp
+++ b/Core/HdAudioDevice.cpp
@@ -41,10 +41,15 @@ bool HdAudioDevice::PlayBgmTrack(uint8_t track, uint32_t startOffset)
 {
 	int trackId = _album * 256 + track;
 	auto result = _hdData->BgmFilesById.find(trackId);
-	auto result2 = _hdData->BgmLoopPointsById.find(trackId);
 	if(result != _hdData->BgmFilesById.end()) {
-		if(_oggMixer->Play(result->second, false, startOffset, result2->second)) {
+		if(_oggMixer->Play(result->second.File, false, startOffset, result->second.LoopPoint)) {
 			_lastBgmTrack = trackId;
+			if (result->second.PlaybackOptions != -1) {
+				_oggMixer->SetPlaybackOptions(result->second.PlaybackOptions);
+			}
+			if (result->second.Volume != -1) {
+				_oggMixer->SetBgmVolume(result->second.Volume);
+			}
 			return true;
 		}
 	} else {

--- a/Core/HdBuilderPpu.h
+++ b/Core/HdBuilderPpu.h
@@ -65,6 +65,16 @@ protected:
 					sprite.TileIndex = (isChrRam ? (_lastSprite->TileAddr & _chrRamIndexMask) : _lastSprite->AbsoluteTileAddr) / 16;
 					sprite.PaletteColors = ReadPaletteRAM(_lastSprite->PaletteOffset + 3) | (ReadPaletteRAM(_lastSprite->PaletteOffset + 2) << 8) | (ReadPaletteRAM(_lastSprite->PaletteOffset + 1) << 16) | 0xFF000000;
 					sprite.IsChrRamTile = isChrRam;
+					sprite.BackgroundPriority = _lastSprite->BackgroundPriority;
+					sprite.HorizontalMirroring = _lastSprite->HorizontalMirror;
+					sprite.VerticalMirroring = _lastSprite->VerticalMirror;
+					sprite.OffsetX = (int32_t)_cycle - _lastSprite->SpriteX - 1;
+					if (_lastSprite->OffsetY >= 8) {
+						sprite.OffsetY = _lastSprite->OffsetY - 8;
+					}
+					else {
+						sprite.OffsetY = _lastSprite->OffsetY;
+					}
 					_console->GetMapper()->CopyChrTile(_lastSprite->AbsoluteTileAddr & 0xFFFFFFF0, sprite.TileData);
 
 					_hdPackBuilder->ProcessTile(_cycle - 1, _scanline, _lastSprite->AbsoluteTileAddr, sprite, mapper, false, _bankHashes[_lastSprite->TileAddr / _chrRamBankSize], false);
@@ -77,6 +87,8 @@ protected:
 					tile.TileIndex = (isChrRam ? (lastTile->TileAddr & _chrRamIndexMask) : lastTile->AbsoluteTileAddr) / 16;
 					tile.PaletteColors = ReadPaletteRAM(lastTile->PaletteOffset + 3) | (ReadPaletteRAM(lastTile->PaletteOffset + 2) << 8) | (ReadPaletteRAM(lastTile->PaletteOffset + 1) << 16) | (ReadPaletteRAM(0) << 24);
 					tile.IsChrRamTile = isChrRam;
+					tile.OffsetX = (_state.XScroll + ((_cycle - 1) & 0x07)) & 0x07;
+					tile.OffsetY = lastTile->OffsetY;
 					_console->GetMapper()->CopyChrTile(lastTile->AbsoluteTileAddr & 0xFFFFFFF0, tile.TileData);
 
 					_hdPackBuilder->ProcessTile(_cycle - 1, _scanline, lastTile->AbsoluteTileAddr, tile, mapper, false, _bankHashes[lastTile->TileAddr / _chrRamBankSize], hasBgSprite);
@@ -121,10 +133,12 @@ public:
 
 	void SendFrame()
 	{
+
 		if(_hdData) {
 			HdPpu::SendFrame();
 		} else {
 			PPU::SendFrame();
 		}
+		_hdPackBuilder->endFrame();
 	}
 };

--- a/Core/HdData.h
+++ b/Core/HdData.h
@@ -346,6 +346,14 @@ struct HdBackgroundInfo
 	}
 };
 
+
+struct HdBGMInfo {
+	string File;
+	uint32_t LoopPoint;
+	int16_t Volume;
+	int16_t PlaybackOptions;
+};
+
 struct HdPackData
 {
 	vector<HdBackgroundInfo> Backgrounds;
@@ -355,8 +363,7 @@ struct HdPackData
 	std::unordered_set<uint32_t> WatchedMemoryAddresses;
 	std::unordered_map<HdTileKey, vector<HdPackTileInfo*>> TileByKey;
 	std::unordered_map<string, string> PatchesByHash;
-	std::unordered_map<int, string> BgmFilesById;
-	std::unordered_map<int, uint32_t> BgmLoopPointsById;
+	std::unordered_map<int, HdBGMInfo> BgmFilesById;
 	std::unordered_map<int, string> SfxFilesById;
 	vector<uint32_t> Palette;
 
@@ -381,4 +388,14 @@ enum class HdPackOptions
 	AlternateRegisterRange = 2,
 	DisableCache = 8,
 	DontRenderOriginalTiles = 16
+};
+
+struct HdScreenTileInfo : public HdTileKey
+{
+	int16_t ScreenX;
+	int16_t ScreenY;
+	bool HorizontalMirroring;
+	bool VerticalMirroring;
+	bool BackgroundPriority;
+	bool IsNew;
 };

--- a/Core/HdPackBuilder.cpp
+++ b/Core/HdPackBuilder.cpp
@@ -5,6 +5,7 @@
 #include "HdNesPack.h"
 #include "Console.h"
 #include "ConsolePauseHelper.h"
+#include "VideoDecoder.h"
 
 HdPackBuilder* HdPackBuilder::_instance = nullptr;
 
@@ -15,6 +16,7 @@ enum HdPackRecordFlags
 	SortByUsageFrequency = 2,
 	GroupBlankTiles = 4,
 	IgnoreOverscan = 8,
+	SaveFrame = 16,
 };
 
 HdPackBuilder::HdPackBuilder(shared_ptr<Console> console, string saveFolder, ScaleFilterType filterType, uint32_t scale, uint32_t flags, uint32_t chrRamBankSize, bool isChrRam)
@@ -25,7 +27,8 @@ HdPackBuilder::HdPackBuilder(shared_ptr<Console> console, string saveFolder, Sca
 	_chrRamBankSize = chrRamBankSize;
 	_flags = flags;
 	_isChrRam = isChrRam;
-
+	_hasNewTile = false;
+	_frameID = 0;
 	string existingPackDefinition = FolderUtilities::CombinePath(saveFolder, "hires.txt");
 	if(ifstream(existingPackDefinition)) {
 		HdPackLoader::LoadHdNesPack(existingPackDefinition, _hdData);
@@ -41,16 +44,128 @@ HdPackBuilder::HdPackBuilder(shared_ptr<Console> console, string saveFolder, Sca
 		_hdData.Scale = scale;
 	}
 
+	if (_flags & (HdPackRecordFlags::SaveFrame)) {
+		uint32_t foundID;
+		vector<string> screenFiles = FolderUtilities::GetFilesInFolder(saveFolder, { ".png", ".csv" }, false);
+		string filePrefix = FolderUtilities::CombinePath(_saveFolder, "");
+		for (string path : screenFiles) {
+			if (path.compare(filePrefix.length(), 7, "screen_") == 0) {
+				
+				foundID = std::stoi(path.substr(filePrefix.length() + 7, path.length() - filePrefix.length() - 11));
+				if (foundID >= _frameID) {
+					_frameID = foundID + 1;
+				}
+			}
+		}
+		FolderUtilities::CreateFolder(_saveFolder);
+	}
+
+
 	_romName = FolderUtilities::GetFilename(_console->GetRomInfo().RomName, false);
 	_instance = this;
 }
 
 HdPackBuilder::~HdPackBuilder()
 {
+
 	SaveHdPack();
 	if(_instance == this) {
 		_instance = nullptr;
 	}
+}
+
+void HdPackBuilder::endFrame() {
+	if (_hasNewTile && (spritesOnScreen.size() > 0 || bgTilesOnScreen.size() > 0) && _flags & (HdPackRecordFlags::SaveFrame)) {
+		//generate file name suffix
+		string counterStr = std::to_string(_frameID);
+		while (counterStr.length() < 3) {
+			counterStr = "0" + counterStr;
+		}
+
+		//save screen
+		_console->GetVideoDecoder()->TakeScreenshot(FolderUtilities::CombinePath(_saveFolder, "screen_" + counterStr + ".png"));
+
+		//save screen info
+		stringstream ss;
+		ss << "Type,X,Y,Tile,Palette,Background Priority,Horizontal Mirroring,Vertical Mirroring,Is New," << std::endl;
+
+		stringstream ssidx;
+		if (_frameID == 0) {
+			ssidx << "Type,Tile,Palette,Screen ID," << std::endl;
+		}
+
+		for (HdScreenTileInfo t:spritesOnScreen) {
+			ss << "Sprite," << t.ScreenX << "," << t.ScreenY << ",";
+
+			if (t.IsChrRamTile) {
+				for (int i = 0; i < 16; i++) {
+					ss << HexUtilities::ToHex(t.TileData[i]);
+				}
+			}
+			else {
+				ss << HexUtilities::ToHex(t.TileIndex);
+			}
+			ss << "," << HexUtilities::ToHex(t.PaletteColors, true) << "," <<
+				(t.BackgroundPriority ? "Y" : "N") << "," << 
+				(t.HorizontalMirroring ? "Y" : "N") << "," << 
+				(t.VerticalMirroring ? "Y" : "N") << "," <<
+				(t.IsNew ? "Y" : "N") << "," << std::endl;
+
+			if (t.IsNew) {
+				ssidx << "Sprite,";
+				if (t.IsChrRamTile) {
+					for (int i = 0; i < 16; i++) {
+						ssidx << HexUtilities::ToHex(t.TileData[i]);
+					}
+				}
+				else {
+					ssidx << HexUtilities::ToHex(t.TileIndex);
+				}
+				ssidx << "," << HexUtilities::ToHex(t.PaletteColors, true) << "," << counterStr << "," << std::endl;
+			}
+		}
+
+		for (HdScreenTileInfo t : bgTilesOnScreen) {
+			ss << "Background," << t.ScreenX << "," << t.ScreenY << ",";
+
+			if (t.IsChrRamTile) {
+				for (int i = 0; i < 16; i++) {
+					ss << HexUtilities::ToHex(t.TileData[i]);
+				}
+			}
+			else {
+				ss << HexUtilities::ToHex(t.TileIndex);
+			}
+			ss << "," << HexUtilities::ToHex(t.PaletteColors, true) << ",,,," << (t.IsNew ? "Y" : "N") << "," << std::endl;
+
+			if (t.IsNew) {
+				ssidx << "Background,";
+				if (t.IsChrRamTile) {
+					for (int i = 0; i < 16; i++) {
+						ssidx << HexUtilities::ToHex(t.TileData[i]);
+					}
+				}
+				else {
+					ssidx << HexUtilities::ToHex(t.TileIndex);
+				}
+				ssidx << "," << HexUtilities::ToHex(t.PaletteColors, true) << "," << counterStr << "," << std::endl;
+			}
+		}
+
+		ofstream screenInfoFile(FolderUtilities::CombinePath(_saveFolder, "screen_" + counterStr + ".csv"), ios::out);
+		screenInfoFile << ss.str();
+		screenInfoFile.close();
+
+		ofstream tileIndexFile(FolderUtilities::CombinePath(_saveFolder, "tileIndex.csv"), ios::app);
+		tileIndexFile << ssidx.str();
+		tileIndexFile.close();
+
+		_frameID++;
+	}
+	//reset for next frame
+	_hasNewTile = false;
+	spritesOnScreen.clear();
+	bgTilesOnScreen.clear();
 }
 
 void HdPackBuilder::AddTile(HdPackTileInfo *tile, uint32_t usageCount)
@@ -93,6 +208,7 @@ void HdPackBuilder::AddTile(HdPackTileInfo *tile, uint32_t usageCount)
 
 	_tilesByKey[tile->GetKey(false)] = tile;
 	_tileUsageCount[tile->GetKey(false)] = usageCount;
+	_hasNewTile = true;
 }
 
 void HdPackBuilder::ProcessTile(uint32_t x, uint32_t y, uint16_t tileAddr, HdPpuTileInfo &tile, BaseMapper *mapper, bool isSprite, uint32_t chrBankHash, bool transparencyRequired)
@@ -110,7 +226,7 @@ void HdPackBuilder::ProcessTile(uint32_t x, uint32_t y, uint16_t tileAddr, HdPpu
 		//Check to see if a default tile matches
 		result = _tileUsageCount.find(tile.GetKey(true));
 	}
-
+	bool isNew = false;
 	if(result == _tileUsageCount.end()) {
 		//First time seeing this tile/palette combination, store it
 		HdPackTileInfo* hdTile = new HdPackTileInfo();
@@ -126,6 +242,7 @@ void HdPackBuilder::ProcessTile(uint32_t x, uint32_t y, uint16_t tileAddr, HdPpu
 
 		_hdData.Tiles.push_back(unique_ptr<HdPackTileInfo>(hdTile));
 		AddTile(hdTile, 1);
+		isNew = true;
 	} else {
 		if(transparencyRequired) {
 			auto existingTile = _tilesByKey.find(tile.GetKey(false));
@@ -137,6 +254,26 @@ void HdPackBuilder::ProcessTile(uint32_t x, uint32_t y, uint16_t tileAddr, HdPpu
 		if(result->second < 0x7FFFFFFF) {
 			//Increase usage count
 			result->second++;
+		}
+	}
+
+	if ((x == 0 || ((tile.OffsetX & 0x07) == 0)) && (y == 0 || ((tile.OffsetY & 0x07) == 0))) {
+		HdScreenTileInfo t;
+		t.IsChrRamTile = tile.IsChrRamTile;
+		t.PaletteColors = tile.PaletteColors;
+		t.ScreenX = x - tile.OffsetX;
+		t.ScreenY = y - tile.OffsetY - (tile.IsSpriteTile() ? 1 : 0);
+		memcpy(t.TileData, tile.TileData, 16);
+		t.TileIndex = tile.TileIndex;
+		t.IsNew = isNew;
+		if (tile.IsSpriteTile()) {
+			t.BackgroundPriority = tile.BackgroundPriority;
+			t.HorizontalMirroring = tile.HorizontalMirroring;
+			t.VerticalMirroring = tile.VerticalMirroring;
+			spritesOnScreen.push_back(t);
+		}
+		else {
+			bgTilesOnScreen.push_back(t);
 		}
 	}
 }
@@ -352,7 +489,7 @@ void HdPackBuilder::SaveHdPack()
 	}
 
 	for(auto &bgmInfo : _hdData.BgmFilesById) {
-		ss << "<bgm>" << std::to_string(bgmInfo.first >> 8) << "," << std::to_string(bgmInfo.first & 0xFF) << "," << VirtualFile(bgmInfo.second).GetFileName() << std::endl;
+		ss << "<bgm>" << std::to_string(bgmInfo.first >> 8) << "," << std::to_string(bgmInfo.first & 0xFF) << "," << VirtualFile(bgmInfo.second.File).GetFileName() << "," << bgmInfo.second.LoopPoint << "," << bgmInfo.second.PlaybackOptions << "," << bgmInfo.second.Volume << std::endl;
 	}
 
 	for(auto &sfxInfo : _hdData.SfxFilesById) {

--- a/Core/HdPackBuilder.h
+++ b/Core/HdPackBuilder.h
@@ -31,6 +31,11 @@ private:
 	string _saveFolder;
 	string _romName;
 	uint32_t _flags;
+	bool _hasNewTile;
+	uint32_t _frameID;
+	vector<HdScreenTileInfo> spritesOnScreen;
+	vector<HdScreenTileInfo> bgTilesOnScreen;
+
 
 	//Used to group blank tiles together
 	uint32_t _blankTileIndex = 0;
@@ -44,6 +49,7 @@ public:
 	HdPackBuilder(shared_ptr<Console> console, string saveFolder, ScaleFilterType filterType, uint32_t scale, uint32_t flags, uint32_t chrRamBankSize, bool isChrRam);
 	~HdPackBuilder();
 
+	void endFrame();
 	void ProcessTile(uint32_t x, uint32_t y, uint16_t tileAddr, HdPpuTileInfo& tile, BaseMapper* mapper, bool isSprite, uint32_t chrBankHash, bool transparencyRequired);
 	void SaveHdPack();
 	

--- a/Core/HdPackLoader.cpp
+++ b/Core/HdPackLoader.cpp
@@ -655,7 +655,7 @@ void HdPackLoader::ProcessBgmTag(vector<string> &tokens)
 		} else {
 			_data->BgmFilesById[trackId] = FolderUtilities::CombinePath(_hdPackFolder, tokens[2]);
 		}
-		if (tokens.size() >= 4) {
+		if (tokens.size() >= 4 && _data->Version >= 105) {
 			stringstream pt(tokens[3]);
 			uint32_t loopPoint;
 			pt >> loopPoint;

--- a/Core/HdPackLoader.cpp
+++ b/Core/HdPackLoader.cpp
@@ -651,18 +651,30 @@ void HdPackLoader::ProcessBgmTag(vector<string> &tokens)
 	if(trackId >= 0) {
 		if(_loadFromZip) {
 			VirtualFile file(_hdPackFolder, tokens[2]);
-			_data->BgmFilesById[trackId] = file;
+			_data->BgmFilesById[trackId].File = file;
 		} else {
-			_data->BgmFilesById[trackId] = FolderUtilities::CombinePath(_hdPackFolder, tokens[2]);
+			_data->BgmFilesById[trackId].File = FolderUtilities::CombinePath(_hdPackFolder, tokens[2]);
 		}
-		if (tokens.size() >= 4 && _data->Version >= 105) {
+		_data->BgmFilesById[trackId].LoopPoint = 0;
+		_data->BgmFilesById[trackId].PlaybackOptions = -1;
+		_data->BgmFilesById[trackId].Volume = -1;
+		if (tokens.size() >= 4) {
 			stringstream pt(tokens[3]);
 			uint32_t loopPoint;
 			pt >> loopPoint;
-			_data->BgmLoopPointsById[trackId] = loopPoint;
-		}
-		else {
-			_data->BgmLoopPointsById[trackId] = 0;
+			_data->BgmFilesById[trackId].LoopPoint = loopPoint;
+			if (tokens.size() >= 5) {
+				stringstream pt(tokens[4]);
+				int16_t pbo;
+				pt >> pbo;
+				_data->BgmFilesById[trackId].PlaybackOptions = pbo;
+				if (tokens.size() >= 6) {
+					stringstream pt(tokens[5]);
+					int16_t vol;
+					pt >> vol;
+					_data->BgmFilesById[trackId].Volume = vol;
+				}
+			}
 		}
 	}
 }

--- a/Core/VideoDecoder.cpp
+++ b/Core/VideoDecoder.cpp
@@ -253,6 +253,13 @@ void VideoDecoder::TakeScreenshot()
 	}
 }
 
+void VideoDecoder::TakeScreenshot(string filePath)
+{
+	if (_videoFilter) {
+		_videoFilter->TakeScreenshot(_videoFilterType, filePath);
+	}
+}
+
 void VideoDecoder::TakeScreenshot(std::stringstream &stream, bool rawScreenshot)
 {
 	if(!_ppuOutputBuffer) {

--- a/Core/VideoDecoder.h
+++ b/Core/VideoDecoder.h
@@ -61,6 +61,7 @@ public:
 
 	void DecodeFrame(bool synchronous = false);
 	void TakeScreenshot();
+	void TakeScreenshot(string filePath);
 	void TakeScreenshot(std::stringstream &stream, bool rawScreenshot = false);
 
 	uint32_t GetFrameCount();

--- a/GUI.NET/Dependencies/resources.en.xml
+++ b/GUI.NET/Dependencies/resources.en.xml
@@ -624,6 +624,7 @@
 			<Control ID="chkLargeSprites">Use 8x16 sprite display mode</Control>
 			<Control ID="chkGroupBlankTiles">Group blank tiles</Control>
 			<Control ID="chkIgnoreOverscan">Ignore tiles at the edges of the screen (overscan)</Control>
+			<Control ID="chkSaveFrame">Save frames which the tiles are first shown</Control>
 			<Control ID="lblFolder">Save Folder:</Control>
 			<Control ID="btnSelectFolder">Browse...</Control>
 			<Control ID="btnStartRecording">Start Recording</Control>
@@ -869,6 +870,7 @@
 		<Message ID="HdPackBuilderGroupBlankHelp">This option groups all the blank tiles sequentially into the same PNG&#xA;files - this helps reduce the number of PNG files produced by removing &#xA;almost-empty PNG files containing only blank tiles.</Message>
 		<Message ID="HdPackBuilderLargeSpritesHelp">When enabled, this option will alter the display order of CHR banks&#xA;that contain only sprites to make the sprites easier to edit in the PNG file.</Message>
 		<Message ID="HdPackBuilderIgnoreOverscanHelp">When enabled, this will make the builder ignore any pixels in the overscan area.&#xA;This is useful in games that contain glitches on the outer edge of the screen.&#xA;Incorrect palette combinations due to these glitches will be ignored and won't be shown in the PNG files.</Message>
+		<Message ID="HdPackBuilderSaveFrameHelp">When enabled, the builder will save a screenshot and the composition of the screen in the pack folder when it encounters new tile in a frame.&#xA;This is useful for checking where that tile is used.&#xA;These files are not needed in the pack and should be deleted when sharing the pack.</Message>
 
 		<Message ID="InstallHdPackWrongRom">The selected HD Pack is not compatible with the currently running game and cannot be installed.</Message>
 		<Message ID="InstallHdPackError">An error occurred while trying to install the HD Pack: &#xA;&#xA;{0}</Message>

--- a/GUI.NET/Forms/HdPackEditor/frmHdPackEditor.Designer.cs
+++ b/GUI.NET/Forms/HdPackEditor/frmHdPackEditor.Designer.cs
@@ -27,547 +27,590 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.components = new System.ComponentModel.Container();
-			this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-			this.btnStopRecording = new System.Windows.Forms.Button();
-			this.btnStartRecording = new System.Windows.Forms.Button();
-			this.btnOpenFolder = new System.Windows.Forms.Button();
-			this.grpPreview = new System.Windows.Forms.GroupBox();
-			this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
-			this.picBankPreview = new System.Windows.Forms.PictureBox();
-			this.cboBank = new System.Windows.Forms.ComboBox();
-			this.lblChrBank = new System.Windows.Forms.Label();
-			this.grpOptions = new System.Windows.Forms.GroupBox();
-			this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
-			this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
-			this.chkIgnoreOverscan = new System.Windows.Forms.CheckBox();
-			this.picIgnoreOverscanHelp = new System.Windows.Forms.PictureBox();
-			this.lblBankSize = new System.Windows.Forms.Label();
-			this.lblScale = new System.Windows.Forms.Label();
-			this.flowLayoutPanel3 = new System.Windows.Forms.FlowLayoutPanel();
-			this.chkGroupBlankTiles = new System.Windows.Forms.CheckBox();
-			this.picGroupBlankHelp = new System.Windows.Forms.PictureBox();
-			this.flowLayoutPanel4 = new System.Windows.Forms.FlowLayoutPanel();
-			this.chkSortByFrequency = new System.Windows.Forms.CheckBox();
-			this.picFrequencyHelp = new System.Windows.Forms.PictureBox();
-			this.flowLayoutPanel5 = new System.Windows.Forms.FlowLayoutPanel();
-			this.chkLargeSprites = new System.Windows.Forms.CheckBox();
-			this.picLargeSpritesHelp = new System.Windows.Forms.PictureBox();
-			this.flpBankSize = new System.Windows.Forms.FlowLayoutPanel();
-			this.cboChrBankSize = new System.Windows.Forms.ComboBox();
-			this.picBankSizeHelp = new System.Windows.Forms.PictureBox();
-			this.flowLayoutPanel6 = new System.Windows.Forms.FlowLayoutPanel();
-			this.cboScale = new System.Windows.Forms.ComboBox();
-			this.picScaleHelp = new System.Windows.Forms.PictureBox();
-			this.tableLayoutPanel4 = new System.Windows.Forms.TableLayoutPanel();
-			this.btnSelectFolder = new System.Windows.Forms.Button();
-			this.txtSaveFolder = new System.Windows.Forms.TextBox();
-			this.lblFolder = new System.Windows.Forms.Label();
-			this.tmrRefresh = new System.Windows.Forms.Timer(this.components);
-			this.tableLayoutPanel1.SuspendLayout();
-			this.grpPreview.SuspendLayout();
-			this.tableLayoutPanel3.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.picBankPreview)).BeginInit();
-			this.grpOptions.SuspendLayout();
-			this.tableLayoutPanel2.SuspendLayout();
-			this.flowLayoutPanel1.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.picIgnoreOverscanHelp)).BeginInit();
-			this.flowLayoutPanel3.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.picGroupBlankHelp)).BeginInit();
-			this.flowLayoutPanel4.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.picFrequencyHelp)).BeginInit();
-			this.flowLayoutPanel5.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.picLargeSpritesHelp)).BeginInit();
-			this.flpBankSize.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.picBankSizeHelp)).BeginInit();
-			this.flowLayoutPanel6.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.picScaleHelp)).BeginInit();
-			this.tableLayoutPanel4.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// tableLayoutPanel1
-			// 
-			this.tableLayoutPanel1.ColumnCount = 3;
-			this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-			this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-			this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-			this.tableLayoutPanel1.Controls.Add(this.btnStopRecording, 1, 3);
-			this.tableLayoutPanel1.Controls.Add(this.btnStartRecording, 2, 3);
-			this.tableLayoutPanel1.Controls.Add(this.btnOpenFolder, 0, 3);
-			this.tableLayoutPanel1.Controls.Add(this.grpPreview, 1, 2);
-			this.tableLayoutPanel1.Controls.Add(this.grpOptions, 0, 2);
-			this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel4, 0, 0);
-			this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
-			this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-			this.tableLayoutPanel1.RowCount = 4;
-			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-			this.tableLayoutPanel1.Size = new System.Drawing.Size(612, 374);
-			this.tableLayoutPanel1.TabIndex = 0;
-			// 
-			// btnStopRecording
-			// 
-			this.btnStopRecording.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btnStopRecording.AutoSize = true;
-			this.btnStopRecording.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.btnStopRecording.Image = global::Mesen.GUI.Properties.Resources.Stop;
-			this.btnStopRecording.Location = new System.Drawing.Point(389, 348);
-			this.btnStopRecording.Name = "btnStopRecording";
-			this.btnStopRecording.Size = new System.Drawing.Size(107, 23);
-			this.btnStopRecording.TabIndex = 7;
-			this.btnStopRecording.Text = "Stop Recording";
-			this.btnStopRecording.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
-			this.btnStopRecording.UseVisualStyleBackColor = true;
-			this.btnStopRecording.Click += new System.EventHandler(this.btnStopRecording_Click);
-			// 
-			// btnStartRecording
-			// 
-			this.btnStartRecording.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.btnStartRecording.AutoSize = true;
-			this.btnStartRecording.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.btnStartRecording.Image = global::Mesen.GUI.Properties.Resources.Record;
-			this.btnStartRecording.Location = new System.Drawing.Point(502, 348);
-			this.btnStartRecording.Name = "btnStartRecording";
-			this.btnStartRecording.Size = new System.Drawing.Size(107, 23);
-			this.btnStartRecording.TabIndex = 6;
-			this.btnStartRecording.Text = "Start Recording";
-			this.btnStartRecording.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
-			this.btnStartRecording.UseVisualStyleBackColor = true;
-			this.btnStartRecording.Click += new System.EventHandler(this.btnStartRecording_Click);
-			// 
-			// btnOpenFolder
-			// 
-			this.btnOpenFolder.AutoSize = true;
-			this.btnOpenFolder.Image = global::Mesen.GUI.Properties.Resources.FolderOpen;
-			this.btnOpenFolder.Location = new System.Drawing.Point(3, 348);
-			this.btnOpenFolder.Name = "btnOpenFolder";
-			this.btnOpenFolder.Size = new System.Drawing.Size(119, 23);
-			this.btnOpenFolder.TabIndex = 8;
-			this.btnOpenFolder.Text = "Open Save Folder";
-			this.btnOpenFolder.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
-			this.btnOpenFolder.UseVisualStyleBackColor = true;
-			this.btnOpenFolder.Click += new System.EventHandler(this.btnOpenFolder_Click);
-			// 
-			// grpPreview
-			// 
-			this.tableLayoutPanel1.SetColumnSpan(this.grpPreview, 2);
-			this.grpPreview.Controls.Add(this.tableLayoutPanel3);
-			this.grpPreview.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.grpPreview.Location = new System.Drawing.Point(340, 32);
-			this.grpPreview.Name = "grpPreview";
-			this.grpPreview.Size = new System.Drawing.Size(269, 310);
-			this.grpPreview.TabIndex = 0;
-			this.grpPreview.TabStop = false;
-			this.grpPreview.Text = "CHR Bank Preview";
-			// 
-			// tableLayoutPanel3
-			// 
-			this.tableLayoutPanel3.ColumnCount = 2;
-			this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-			this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-			this.tableLayoutPanel3.Controls.Add(this.picBankPreview, 0, 1);
-			this.tableLayoutPanel3.Controls.Add(this.cboBank, 1, 0);
-			this.tableLayoutPanel3.Controls.Add(this.lblChrBank, 0, 0);
-			this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.tableLayoutPanel3.Location = new System.Drawing.Point(3, 16);
-			this.tableLayoutPanel3.Name = "tableLayoutPanel3";
-			this.tableLayoutPanel3.RowCount = 2;
-			this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-			this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-			this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-			this.tableLayoutPanel3.Size = new System.Drawing.Size(263, 291);
-			this.tableLayoutPanel3.TabIndex = 2;
-			// 
-			// picBankPreview
-			// 
-			this.tableLayoutPanel3.SetColumnSpan(this.picBankPreview, 2);
-			this.picBankPreview.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.picBankPreview.Location = new System.Drawing.Point(3, 30);
-			this.picBankPreview.Name = "picBankPreview";
-			this.picBankPreview.Size = new System.Drawing.Size(257, 258);
-			this.picBankPreview.TabIndex = 0;
-			this.picBankPreview.TabStop = false;
-			// 
-			// cboBank
-			// 
-			this.cboBank.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.cboBank.FormattingEnabled = true;
-			this.cboBank.Location = new System.Drawing.Point(70, 3);
-			this.cboBank.Name = "cboBank";
-			this.cboBank.Size = new System.Drawing.Size(121, 21);
-			this.cboBank.TabIndex = 1;
-			// 
-			// lblChrBank
-			// 
-			this.lblChrBank.Anchor = System.Windows.Forms.AnchorStyles.Left;
-			this.lblChrBank.AutoSize = true;
-			this.lblChrBank.Location = new System.Drawing.Point(3, 7);
-			this.lblChrBank.Name = "lblChrBank";
-			this.lblChrBank.Size = new System.Drawing.Size(61, 13);
-			this.lblChrBank.TabIndex = 3;
-			this.lblChrBank.Text = "CHR Bank:";
-			// 
-			// grpOptions
-			// 
-			this.grpOptions.Controls.Add(this.tableLayoutPanel2);
-			this.grpOptions.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.grpOptions.Location = new System.Drawing.Point(3, 32);
-			this.grpOptions.Name = "grpOptions";
-			this.grpOptions.Size = new System.Drawing.Size(331, 310);
-			this.grpOptions.TabIndex = 4;
-			this.grpOptions.TabStop = false;
-			this.grpOptions.Text = "Recording Options";
-			// 
-			// tableLayoutPanel2
-			// 
-			this.tableLayoutPanel2.ColumnCount = 2;
-			this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-			this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-			this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel1, 0, 6);
-			this.tableLayoutPanel2.Controls.Add(this.lblBankSize, 0, 1);
-			this.tableLayoutPanel2.Controls.Add(this.lblScale, 0, 0);
-			this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel3, 0, 2);
-			this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel4, 0, 3);
-			this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel5, 0, 4);
-			this.tableLayoutPanel2.Controls.Add(this.flpBankSize, 1, 1);
-			this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel6, 1, 0);
-			this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.tableLayoutPanel2.Location = new System.Drawing.Point(3, 16);
-			this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-			this.tableLayoutPanel2.RowCount = 8;
-			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-			this.tableLayoutPanel2.Size = new System.Drawing.Size(325, 291);
-			this.tableLayoutPanel2.TabIndex = 0;
-			// 
-			// flowLayoutPanel1
-			// 
-			this.tableLayoutPanel2.SetColumnSpan(this.flowLayoutPanel1, 2);
-			this.flowLayoutPanel1.Controls.Add(this.chkIgnoreOverscan);
-			this.flowLayoutPanel1.Controls.Add(this.picIgnoreOverscanHelp);
-			this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.flowLayoutPanel1.Location = new System.Drawing.Point(0, 114);
-			this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(0);
-			this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-			this.flowLayoutPanel1.Size = new System.Drawing.Size(325, 20);
-			this.flowLayoutPanel1.TabIndex = 19;
-			// 
-			// chkIgnoreOverscan
-			// 
-			this.chkIgnoreOverscan.AutoSize = true;
-			this.chkIgnoreOverscan.Location = new System.Drawing.Point(3, 3);
-			this.chkIgnoreOverscan.Name = "chkIgnoreOverscan";
-			this.chkIgnoreOverscan.Size = new System.Drawing.Size(257, 17);
-			this.chkIgnoreOverscan.TabIndex = 17;
-			this.chkIgnoreOverscan.Text = "Ignore tiles at the edges of the screen (overscan)";
-			this.chkIgnoreOverscan.UseVisualStyleBackColor = true;
-			// 
-			// picIgnoreOverscanHelp
-			// 
-			this.picIgnoreOverscanHelp.Anchor = System.Windows.Forms.AnchorStyles.Left;
-			this.picIgnoreOverscanHelp.BackgroundImage = global::Mesen.GUI.Properties.Resources.Help;
-			this.picIgnoreOverscanHelp.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
-			this.picIgnoreOverscanHelp.Location = new System.Drawing.Point(266, 3);
-			this.picIgnoreOverscanHelp.Name = "picIgnoreOverscanHelp";
-			this.picIgnoreOverscanHelp.Size = new System.Drawing.Size(16, 16);
-			this.picIgnoreOverscanHelp.TabIndex = 18;
-			this.picIgnoreOverscanHelp.TabStop = false;
-			// 
-			// lblBankSize
-			// 
-			this.lblBankSize.Anchor = System.Windows.Forms.AnchorStyles.Left;
-			this.lblBankSize.AutoSize = true;
-			this.lblBankSize.Location = new System.Drawing.Point(3, 29);
-			this.lblBankSize.Name = "lblBankSize";
-			this.lblBankSize.Size = new System.Drawing.Size(84, 13);
-			this.lblBankSize.TabIndex = 9;
-			this.lblBankSize.Text = "CHR Bank Size:";
-			// 
-			// lblScale
-			// 
-			this.lblScale.Anchor = System.Windows.Forms.AnchorStyles.Left;
-			this.lblScale.AutoSize = true;
-			this.lblScale.Location = new System.Drawing.Point(3, 5);
-			this.lblScale.Name = "lblScale";
-			this.lblScale.Size = new System.Drawing.Size(64, 13);
-			this.lblScale.TabIndex = 4;
-			this.lblScale.Text = "Scale/Filter:";
-			// 
-			// flowLayoutPanel3
-			// 
-			this.tableLayoutPanel2.SetColumnSpan(this.flowLayoutPanel3, 2);
-			this.flowLayoutPanel3.Controls.Add(this.chkGroupBlankTiles);
-			this.flowLayoutPanel3.Controls.Add(this.picGroupBlankHelp);
-			this.flowLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.flowLayoutPanel3.Location = new System.Drawing.Point(0, 48);
-			this.flowLayoutPanel3.Margin = new System.Windows.Forms.Padding(0);
-			this.flowLayoutPanel3.Name = "flowLayoutPanel3";
-			this.flowLayoutPanel3.Size = new System.Drawing.Size(325, 22);
-			this.flowLayoutPanel3.TabIndex = 12;
-			// 
-			// chkGroupBlankTiles
-			// 
-			this.chkGroupBlankTiles.AutoSize = true;
-			this.chkGroupBlankTiles.Checked = true;
-			this.chkGroupBlankTiles.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.chkGroupBlankTiles.Location = new System.Drawing.Point(3, 3);
-			this.chkGroupBlankTiles.Name = "chkGroupBlankTiles";
-			this.chkGroupBlankTiles.Size = new System.Drawing.Size(105, 17);
-			this.chkGroupBlankTiles.TabIndex = 11;
-			this.chkGroupBlankTiles.Text = "Group blank tiles";
-			this.chkGroupBlankTiles.UseVisualStyleBackColor = true;
-			// 
-			// picGroupBlankHelp
-			// 
-			this.picGroupBlankHelp.Anchor = System.Windows.Forms.AnchorStyles.Left;
-			this.picGroupBlankHelp.BackgroundImage = global::Mesen.GUI.Properties.Resources.Help;
-			this.picGroupBlankHelp.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
-			this.picGroupBlankHelp.Location = new System.Drawing.Point(114, 3);
-			this.picGroupBlankHelp.Name = "picGroupBlankHelp";
-			this.picGroupBlankHelp.Size = new System.Drawing.Size(16, 16);
-			this.picGroupBlankHelp.TabIndex = 12;
-			this.picGroupBlankHelp.TabStop = false;
-			// 
-			// flowLayoutPanel4
-			// 
-			this.tableLayoutPanel2.SetColumnSpan(this.flowLayoutPanel4, 2);
-			this.flowLayoutPanel4.Controls.Add(this.chkSortByFrequency);
-			this.flowLayoutPanel4.Controls.Add(this.picFrequencyHelp);
-			this.flowLayoutPanel4.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.flowLayoutPanel4.Location = new System.Drawing.Point(0, 70);
-			this.flowLayoutPanel4.Margin = new System.Windows.Forms.Padding(0);
-			this.flowLayoutPanel4.Name = "flowLayoutPanel4";
-			this.flowLayoutPanel4.Size = new System.Drawing.Size(325, 22);
-			this.flowLayoutPanel4.TabIndex = 13;
-			// 
-			// chkSortByFrequency
-			// 
-			this.chkSortByFrequency.AutoSize = true;
-			this.chkSortByFrequency.Checked = true;
-			this.chkSortByFrequency.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.chkSortByFrequency.Location = new System.Drawing.Point(3, 3);
-			this.chkSortByFrequency.Name = "chkSortByFrequency";
-			this.chkSortByFrequency.Size = new System.Drawing.Size(173, 17);
-			this.chkSortByFrequency.TabIndex = 3;
-			this.chkSortByFrequency.Text = "Sort pages by usage frequency";
-			this.chkSortByFrequency.UseVisualStyleBackColor = true;
-			// 
-			// picFrequencyHelp
-			// 
-			this.picFrequencyHelp.Anchor = System.Windows.Forms.AnchorStyles.Left;
-			this.picFrequencyHelp.BackgroundImage = global::Mesen.GUI.Properties.Resources.Help;
-			this.picFrequencyHelp.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
-			this.picFrequencyHelp.Location = new System.Drawing.Point(182, 3);
-			this.picFrequencyHelp.Name = "picFrequencyHelp";
-			this.picFrequencyHelp.Size = new System.Drawing.Size(16, 16);
-			this.picFrequencyHelp.TabIndex = 12;
-			this.picFrequencyHelp.TabStop = false;
-			// 
-			// flowLayoutPanel5
-			// 
-			this.tableLayoutPanel2.SetColumnSpan(this.flowLayoutPanel5, 2);
-			this.flowLayoutPanel5.Controls.Add(this.chkLargeSprites);
-			this.flowLayoutPanel5.Controls.Add(this.picLargeSpritesHelp);
-			this.flowLayoutPanel5.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.flowLayoutPanel5.Location = new System.Drawing.Point(0, 92);
-			this.flowLayoutPanel5.Margin = new System.Windows.Forms.Padding(0);
-			this.flowLayoutPanel5.Name = "flowLayoutPanel5";
-			this.flowLayoutPanel5.Size = new System.Drawing.Size(325, 22);
-			this.flowLayoutPanel5.TabIndex = 14;
-			// 
-			// chkLargeSprites
-			// 
-			this.chkLargeSprites.AutoSize = true;
-			this.chkLargeSprites.Location = new System.Drawing.Point(3, 3);
-			this.chkLargeSprites.Name = "chkLargeSprites";
-			this.chkLargeSprites.Size = new System.Drawing.Size(163, 17);
-			this.chkLargeSprites.TabIndex = 8;
-			this.chkLargeSprites.Text = "Use 8x16 sprite display mode";
-			this.chkLargeSprites.UseVisualStyleBackColor = true;
-			// 
-			// picLargeSpritesHelp
-			// 
-			this.picLargeSpritesHelp.Anchor = System.Windows.Forms.AnchorStyles.Left;
-			this.picLargeSpritesHelp.BackgroundImage = global::Mesen.GUI.Properties.Resources.Help;
-			this.picLargeSpritesHelp.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
-			this.picLargeSpritesHelp.Location = new System.Drawing.Point(172, 3);
-			this.picLargeSpritesHelp.Name = "picLargeSpritesHelp";
-			this.picLargeSpritesHelp.Size = new System.Drawing.Size(16, 16);
-			this.picLargeSpritesHelp.TabIndex = 12;
-			this.picLargeSpritesHelp.TabStop = false;
-			// 
-			// flpBankSize
-			// 
-			this.flpBankSize.Controls.Add(this.cboChrBankSize);
-			this.flpBankSize.Controls.Add(this.picBankSizeHelp);
-			this.flpBankSize.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.flpBankSize.Location = new System.Drawing.Point(90, 24);
-			this.flpBankSize.Margin = new System.Windows.Forms.Padding(0);
-			this.flpBankSize.Name = "flpBankSize";
-			this.flpBankSize.Size = new System.Drawing.Size(235, 24);
-			this.flpBankSize.TabIndex = 15;
-			// 
-			// cboChrBankSize
-			// 
-			this.cboChrBankSize.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.cboChrBankSize.FormattingEnabled = true;
-			this.cboChrBankSize.Items.AddRange(new object[] {
+            this.components = new System.ComponentModel.Container();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.btnStopRecording = new System.Windows.Forms.Button();
+            this.btnStartRecording = new System.Windows.Forms.Button();
+            this.btnOpenFolder = new System.Windows.Forms.Button();
+            this.grpPreview = new System.Windows.Forms.GroupBox();
+            this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
+            this.picBankPreview = new System.Windows.Forms.PictureBox();
+            this.cboBank = new System.Windows.Forms.ComboBox();
+            this.lblChrBank = new System.Windows.Forms.Label();
+            this.grpOptions = new System.Windows.Forms.GroupBox();
+            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+            this.chkIgnoreOverscan = new System.Windows.Forms.CheckBox();
+            this.picIgnoreOverscanHelp = new System.Windows.Forms.PictureBox();
+            this.lblBankSize = new System.Windows.Forms.Label();
+            this.lblScale = new System.Windows.Forms.Label();
+            this.flowLayoutPanel3 = new System.Windows.Forms.FlowLayoutPanel();
+            this.chkGroupBlankTiles = new System.Windows.Forms.CheckBox();
+            this.picGroupBlankHelp = new System.Windows.Forms.PictureBox();
+            this.flowLayoutPanel4 = new System.Windows.Forms.FlowLayoutPanel();
+            this.chkSortByFrequency = new System.Windows.Forms.CheckBox();
+            this.picFrequencyHelp = new System.Windows.Forms.PictureBox();
+            this.flowLayoutPanel5 = new System.Windows.Forms.FlowLayoutPanel();
+            this.chkLargeSprites = new System.Windows.Forms.CheckBox();
+            this.picLargeSpritesHelp = new System.Windows.Forms.PictureBox();
+            this.flpBankSize = new System.Windows.Forms.FlowLayoutPanel();
+            this.cboChrBankSize = new System.Windows.Forms.ComboBox();
+            this.picBankSizeHelp = new System.Windows.Forms.PictureBox();
+            this.flowLayoutPanel6 = new System.Windows.Forms.FlowLayoutPanel();
+            this.cboScale = new System.Windows.Forms.ComboBox();
+            this.picScaleHelp = new System.Windows.Forms.PictureBox();
+            this.flowLayoutPanel2 = new System.Windows.Forms.FlowLayoutPanel();
+            this.chkSaveFrame = new System.Windows.Forms.CheckBox();
+            this.picSaveFrameHelp = new System.Windows.Forms.PictureBox();
+            this.tableLayoutPanel4 = new System.Windows.Forms.TableLayoutPanel();
+            this.btnSelectFolder = new System.Windows.Forms.Button();
+            this.txtSaveFolder = new System.Windows.Forms.TextBox();
+            this.lblFolder = new System.Windows.Forms.Label();
+            this.tmrRefresh = new System.Windows.Forms.Timer(this.components);
+            this.tableLayoutPanel1.SuspendLayout();
+            this.grpPreview.SuspendLayout();
+            this.tableLayoutPanel3.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.picBankPreview)).BeginInit();
+            this.grpOptions.SuspendLayout();
+            this.tableLayoutPanel2.SuspendLayout();
+            this.flowLayoutPanel1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.picIgnoreOverscanHelp)).BeginInit();
+            this.flowLayoutPanel3.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.picGroupBlankHelp)).BeginInit();
+            this.flowLayoutPanel4.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.picFrequencyHelp)).BeginInit();
+            this.flowLayoutPanel5.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.picLargeSpritesHelp)).BeginInit();
+            this.flpBankSize.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.picBankSizeHelp)).BeginInit();
+            this.flowLayoutPanel6.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.picScaleHelp)).BeginInit();
+            this.flowLayoutPanel2.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.picSaveFrameHelp)).BeginInit();
+            this.tableLayoutPanel4.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.ColumnCount = 3;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel1.Controls.Add(this.btnStopRecording, 1, 3);
+            this.tableLayoutPanel1.Controls.Add(this.btnStartRecording, 2, 3);
+            this.tableLayoutPanel1.Controls.Add(this.btnOpenFolder, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this.grpPreview, 1, 2);
+            this.tableLayoutPanel1.Controls.Add(this.grpOptions, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel4, 0, 0);
+            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 4;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(612, 345);
+            this.tableLayoutPanel1.TabIndex = 0;
+            // 
+            // btnStopRecording
+            // 
+            this.btnStopRecording.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnStopRecording.AutoSize = true;
+            this.btnStopRecording.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.btnStopRecording.Image = global::Mesen.GUI.Properties.Resources.Stop;
+            this.btnStopRecording.Location = new System.Drawing.Point(395, 322);
+            this.btnStopRecording.Name = "btnStopRecording";
+            this.btnStopRecording.Size = new System.Drawing.Size(104, 20);
+            this.btnStopRecording.TabIndex = 12;
+            this.btnStopRecording.Text = "Stop Recording";
+            this.btnStopRecording.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
+            this.btnStopRecording.UseVisualStyleBackColor = true;
+            this.btnStopRecording.Click += new System.EventHandler(this.btnStopRecording_Click);
+            // 
+            // btnStartRecording
+            // 
+            this.btnStartRecording.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnStartRecording.AutoSize = true;
+            this.btnStartRecording.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.btnStartRecording.Image = global::Mesen.GUI.Properties.Resources.Record;
+            this.btnStartRecording.Location = new System.Drawing.Point(505, 322);
+            this.btnStartRecording.Name = "btnStartRecording";
+            this.btnStartRecording.Size = new System.Drawing.Size(104, 20);
+            this.btnStartRecording.TabIndex = 13;
+            this.btnStartRecording.Text = "Start Recording";
+            this.btnStartRecording.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
+            this.btnStartRecording.UseVisualStyleBackColor = true;
+            this.btnStartRecording.Click += new System.EventHandler(this.btnStartRecording_Click);
+            // 
+            // btnOpenFolder
+            // 
+            this.btnOpenFolder.AutoSize = true;
+            this.btnOpenFolder.Image = global::Mesen.GUI.Properties.Resources.FolderOpen;
+            this.btnOpenFolder.Location = new System.Drawing.Point(3, 322);
+            this.btnOpenFolder.Name = "btnOpenFolder";
+            this.btnOpenFolder.Size = new System.Drawing.Size(119, 20);
+            this.btnOpenFolder.TabIndex = 11;
+            this.btnOpenFolder.Text = "Open Save Folder";
+            this.btnOpenFolder.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
+            this.btnOpenFolder.UseVisualStyleBackColor = true;
+            this.btnOpenFolder.Click += new System.EventHandler(this.btnOpenFolder_Click);
+            // 
+            // grpPreview
+            // 
+            this.tableLayoutPanel1.SetColumnSpan(this.grpPreview, 2);
+            this.grpPreview.Controls.Add(this.tableLayoutPanel3);
+            this.grpPreview.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.grpPreview.Location = new System.Drawing.Point(340, 30);
+            this.grpPreview.Name = "grpPreview";
+            this.grpPreview.Size = new System.Drawing.Size(269, 286);
+            this.grpPreview.TabIndex = 0;
+            this.grpPreview.TabStop = false;
+            this.grpPreview.Text = "CHR Bank Preview";
+            // 
+            // tableLayoutPanel3
+            // 
+            this.tableLayoutPanel3.ColumnCount = 2;
+            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel3.Controls.Add(this.picBankPreview, 0, 1);
+            this.tableLayoutPanel3.Controls.Add(this.cboBank, 1, 0);
+            this.tableLayoutPanel3.Controls.Add(this.lblChrBank, 0, 0);
+            this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel3.Location = new System.Drawing.Point(3, 18);
+            this.tableLayoutPanel3.Name = "tableLayoutPanel3";
+            this.tableLayoutPanel3.RowCount = 2;
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 18F));
+            this.tableLayoutPanel3.Size = new System.Drawing.Size(263, 265);
+            this.tableLayoutPanel3.TabIndex = 2;
+            // 
+            // picBankPreview
+            // 
+            this.tableLayoutPanel3.SetColumnSpan(this.picBankPreview, 2);
+            this.picBankPreview.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.picBankPreview.Location = new System.Drawing.Point(3, 29);
+            this.picBankPreview.Name = "picBankPreview";
+            this.picBankPreview.Size = new System.Drawing.Size(257, 233);
+            this.picBankPreview.TabIndex = 0;
+            this.picBankPreview.TabStop = false;
+            // 
+            // cboBank
+            // 
+            this.cboBank.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cboBank.FormattingEnabled = true;
+            this.cboBank.Location = new System.Drawing.Point(69, 3);
+            this.cboBank.Name = "cboBank";
+            this.cboBank.Size = new System.Drawing.Size(121, 20);
+            this.cboBank.TabIndex = 10;
+            // 
+            // lblChrBank
+            // 
+            this.lblChrBank.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.lblChrBank.AutoSize = true;
+            this.lblChrBank.Location = new System.Drawing.Point(3, 7);
+            this.lblChrBank.Name = "lblChrBank";
+            this.lblChrBank.Size = new System.Drawing.Size(60, 12);
+            this.lblChrBank.TabIndex = 3;
+            this.lblChrBank.Text = "CHR Bank:";
+            // 
+            // grpOptions
+            // 
+            this.grpOptions.Controls.Add(this.tableLayoutPanel2);
+            this.grpOptions.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.grpOptions.Location = new System.Drawing.Point(3, 30);
+            this.grpOptions.Name = "grpOptions";
+            this.grpOptions.Size = new System.Drawing.Size(331, 286);
+            this.grpOptions.TabIndex = 4;
+            this.grpOptions.TabStop = false;
+            this.grpOptions.Text = "Recording Options";
+            // 
+            // tableLayoutPanel2
+            // 
+            this.tableLayoutPanel2.ColumnCount = 2;
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel1, 0, 6);
+            this.tableLayoutPanel2.Controls.Add(this.lblBankSize, 0, 1);
+            this.tableLayoutPanel2.Controls.Add(this.lblScale, 0, 0);
+            this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel3, 0, 2);
+            this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel4, 0, 3);
+            this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel5, 0, 4);
+            this.tableLayoutPanel2.Controls.Add(this.flpBankSize, 1, 1);
+            this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel6, 1, 0);
+            this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel2, 0, 7);
+            this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel2.Location = new System.Drawing.Point(3, 18);
+            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
+            this.tableLayoutPanel2.RowCount = 9;
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 18F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 18F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(325, 265);
+            this.tableLayoutPanel2.TabIndex = 0;
+            // 
+            // flowLayoutPanel1
+            // 
+            this.tableLayoutPanel2.SetColumnSpan(this.flowLayoutPanel1, 2);
+            this.flowLayoutPanel1.Controls.Add(this.chkIgnoreOverscan);
+            this.flowLayoutPanel1.Controls.Add(this.picIgnoreOverscanHelp);
+            this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(0, 104);
+            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(0);
+            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(325, 18);
+            this.flowLayoutPanel1.TabIndex = 19;
+            // 
+            // chkIgnoreOverscan
+            // 
+            this.chkIgnoreOverscan.AutoSize = true;
+            this.chkIgnoreOverscan.Location = new System.Drawing.Point(3, 3);
+            this.chkIgnoreOverscan.Name = "chkIgnoreOverscan";
+            this.chkIgnoreOverscan.Size = new System.Drawing.Size(247, 16);
+            this.chkIgnoreOverscan.TabIndex = 8;
+            this.chkIgnoreOverscan.Text = "Ignore tiles at the edges of the screen (overscan)";
+            this.chkIgnoreOverscan.UseVisualStyleBackColor = true;
+            // 
+            // picIgnoreOverscanHelp
+            // 
+            this.picIgnoreOverscanHelp.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.picIgnoreOverscanHelp.BackgroundImage = global::Mesen.GUI.Properties.Resources.Help;
+            this.picIgnoreOverscanHelp.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
+            this.picIgnoreOverscanHelp.Location = new System.Drawing.Point(256, 3);
+            this.picIgnoreOverscanHelp.Name = "picIgnoreOverscanHelp";
+            this.picIgnoreOverscanHelp.Size = new System.Drawing.Size(16, 15);
+            this.picIgnoreOverscanHelp.TabIndex = 18;
+            this.picIgnoreOverscanHelp.TabStop = false;
+            // 
+            // lblBankSize
+            // 
+            this.lblBankSize.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.lblBankSize.AutoSize = true;
+            this.lblBankSize.Location = new System.Drawing.Point(3, 27);
+            this.lblBankSize.Name = "lblBankSize";
+            this.lblBankSize.Size = new System.Drawing.Size(82, 12);
+            this.lblBankSize.TabIndex = 9;
+            this.lblBankSize.Text = "CHR Bank Size:";
+            // 
+            // lblScale
+            // 
+            this.lblScale.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.lblScale.AutoSize = true;
+            this.lblScale.Location = new System.Drawing.Point(3, 5);
+            this.lblScale.Name = "lblScale";
+            this.lblScale.Size = new System.Drawing.Size(59, 12);
+            this.lblScale.TabIndex = 4;
+            this.lblScale.Text = "Scale/Filter:";
+            // 
+            // flowLayoutPanel3
+            // 
+            this.tableLayoutPanel2.SetColumnSpan(this.flowLayoutPanel3, 2);
+            this.flowLayoutPanel3.Controls.Add(this.chkGroupBlankTiles);
+            this.flowLayoutPanel3.Controls.Add(this.picGroupBlankHelp);
+            this.flowLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel3.Location = new System.Drawing.Point(0, 44);
+            this.flowLayoutPanel3.Margin = new System.Windows.Forms.Padding(0);
+            this.flowLayoutPanel3.Name = "flowLayoutPanel3";
+            this.flowLayoutPanel3.Size = new System.Drawing.Size(325, 20);
+            this.flowLayoutPanel3.TabIndex = 12;
+            // 
+            // chkGroupBlankTiles
+            // 
+            this.chkGroupBlankTiles.AutoSize = true;
+            this.chkGroupBlankTiles.Checked = true;
+            this.chkGroupBlankTiles.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkGroupBlankTiles.Location = new System.Drawing.Point(3, 3);
+            this.chkGroupBlankTiles.Name = "chkGroupBlankTiles";
+            this.chkGroupBlankTiles.Size = new System.Drawing.Size(104, 16);
+            this.chkGroupBlankTiles.TabIndex = 5;
+            this.chkGroupBlankTiles.Text = "Group blank tiles";
+            this.chkGroupBlankTiles.UseVisualStyleBackColor = true;
+            // 
+            // picGroupBlankHelp
+            // 
+            this.picGroupBlankHelp.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.picGroupBlankHelp.BackgroundImage = global::Mesen.GUI.Properties.Resources.Help;
+            this.picGroupBlankHelp.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
+            this.picGroupBlankHelp.Location = new System.Drawing.Point(113, 3);
+            this.picGroupBlankHelp.Name = "picGroupBlankHelp";
+            this.picGroupBlankHelp.Size = new System.Drawing.Size(16, 15);
+            this.picGroupBlankHelp.TabIndex = 12;
+            this.picGroupBlankHelp.TabStop = false;
+            // 
+            // flowLayoutPanel4
+            // 
+            this.tableLayoutPanel2.SetColumnSpan(this.flowLayoutPanel4, 2);
+            this.flowLayoutPanel4.Controls.Add(this.chkSortByFrequency);
+            this.flowLayoutPanel4.Controls.Add(this.picFrequencyHelp);
+            this.flowLayoutPanel4.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel4.Location = new System.Drawing.Point(0, 64);
+            this.flowLayoutPanel4.Margin = new System.Windows.Forms.Padding(0);
+            this.flowLayoutPanel4.Name = "flowLayoutPanel4";
+            this.flowLayoutPanel4.Size = new System.Drawing.Size(325, 20);
+            this.flowLayoutPanel4.TabIndex = 13;
+            // 
+            // chkSortByFrequency
+            // 
+            this.chkSortByFrequency.AutoSize = true;
+            this.chkSortByFrequency.Checked = true;
+            this.chkSortByFrequency.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkSortByFrequency.Location = new System.Drawing.Point(3, 3);
+            this.chkSortByFrequency.Name = "chkSortByFrequency";
+            this.chkSortByFrequency.Size = new System.Drawing.Size(166, 16);
+            this.chkSortByFrequency.TabIndex = 6;
+            this.chkSortByFrequency.Text = "Sort pages by usage frequency";
+            this.chkSortByFrequency.UseVisualStyleBackColor = true;
+            // 
+            // picFrequencyHelp
+            // 
+            this.picFrequencyHelp.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.picFrequencyHelp.BackgroundImage = global::Mesen.GUI.Properties.Resources.Help;
+            this.picFrequencyHelp.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
+            this.picFrequencyHelp.Location = new System.Drawing.Point(175, 3);
+            this.picFrequencyHelp.Name = "picFrequencyHelp";
+            this.picFrequencyHelp.Size = new System.Drawing.Size(16, 15);
+            this.picFrequencyHelp.TabIndex = 12;
+            this.picFrequencyHelp.TabStop = false;
+            // 
+            // flowLayoutPanel5
+            // 
+            this.tableLayoutPanel2.SetColumnSpan(this.flowLayoutPanel5, 2);
+            this.flowLayoutPanel5.Controls.Add(this.chkLargeSprites);
+            this.flowLayoutPanel5.Controls.Add(this.picLargeSpritesHelp);
+            this.flowLayoutPanel5.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel5.Location = new System.Drawing.Point(0, 84);
+            this.flowLayoutPanel5.Margin = new System.Windows.Forms.Padding(0);
+            this.flowLayoutPanel5.Name = "flowLayoutPanel5";
+            this.flowLayoutPanel5.Size = new System.Drawing.Size(325, 20);
+            this.flowLayoutPanel5.TabIndex = 14;
+            // 
+            // chkLargeSprites
+            // 
+            this.chkLargeSprites.AutoSize = true;
+            this.chkLargeSprites.Location = new System.Drawing.Point(3, 3);
+            this.chkLargeSprites.Name = "chkLargeSprites";
+            this.chkLargeSprites.Size = new System.Drawing.Size(161, 16);
+            this.chkLargeSprites.TabIndex = 7;
+            this.chkLargeSprites.Text = "Use 8x16 sprite display mode";
+            this.chkLargeSprites.UseVisualStyleBackColor = true;
+            // 
+            // picLargeSpritesHelp
+            // 
+            this.picLargeSpritesHelp.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.picLargeSpritesHelp.BackgroundImage = global::Mesen.GUI.Properties.Resources.Help;
+            this.picLargeSpritesHelp.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
+            this.picLargeSpritesHelp.Location = new System.Drawing.Point(170, 3);
+            this.picLargeSpritesHelp.Name = "picLargeSpritesHelp";
+            this.picLargeSpritesHelp.Size = new System.Drawing.Size(16, 15);
+            this.picLargeSpritesHelp.TabIndex = 12;
+            this.picLargeSpritesHelp.TabStop = false;
+            // 
+            // flpBankSize
+            // 
+            this.flpBankSize.Controls.Add(this.cboChrBankSize);
+            this.flpBankSize.Controls.Add(this.picBankSizeHelp);
+            this.flpBankSize.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flpBankSize.Location = new System.Drawing.Point(88, 22);
+            this.flpBankSize.Margin = new System.Windows.Forms.Padding(0);
+            this.flpBankSize.Name = "flpBankSize";
+            this.flpBankSize.Size = new System.Drawing.Size(237, 22);
+            this.flpBankSize.TabIndex = 15;
+            // 
+            // cboChrBankSize
+            // 
+            this.cboChrBankSize.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cboChrBankSize.FormattingEnabled = true;
+            this.cboChrBankSize.Items.AddRange(new object[] {
             "1 KB",
             "2 KB",
             "4 KB"});
-			this.cboChrBankSize.Location = new System.Drawing.Point(3, 3);
-			this.cboChrBankSize.Name = "cboChrBankSize";
-			this.cboChrBankSize.Size = new System.Drawing.Size(105, 21);
-			this.cboChrBankSize.TabIndex = 10;
-			// 
-			// picBankSizeHelp
-			// 
-			this.picBankSizeHelp.Anchor = System.Windows.Forms.AnchorStyles.Left;
-			this.picBankSizeHelp.BackgroundImage = global::Mesen.GUI.Properties.Resources.Help;
-			this.picBankSizeHelp.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
-			this.picBankSizeHelp.Location = new System.Drawing.Point(114, 6);
-			this.picBankSizeHelp.Margin = new System.Windows.Forms.Padding(3, 5, 3, 3);
-			this.picBankSizeHelp.Name = "picBankSizeHelp";
-			this.picBankSizeHelp.Size = new System.Drawing.Size(16, 16);
-			this.picBankSizeHelp.TabIndex = 12;
-			this.picBankSizeHelp.TabStop = false;
-			// 
-			// flowLayoutPanel6
-			// 
-			this.flowLayoutPanel6.Controls.Add(this.cboScale);
-			this.flowLayoutPanel6.Controls.Add(this.picScaleHelp);
-			this.flowLayoutPanel6.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.flowLayoutPanel6.Location = new System.Drawing.Point(90, 0);
-			this.flowLayoutPanel6.Margin = new System.Windows.Forms.Padding(0);
-			this.flowLayoutPanel6.Name = "flowLayoutPanel6";
-			this.flowLayoutPanel6.Size = new System.Drawing.Size(235, 24);
-			this.flowLayoutPanel6.TabIndex = 16;
-			// 
-			// cboScale
-			// 
-			this.cboScale.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.cboScale.FormattingEnabled = true;
-			this.cboScale.Location = new System.Drawing.Point(3, 3);
-			this.cboScale.Name = "cboScale";
-			this.cboScale.Size = new System.Drawing.Size(105, 21);
-			this.cboScale.TabIndex = 5;
-			// 
-			// picScaleHelp
-			// 
-			this.picScaleHelp.Anchor = System.Windows.Forms.AnchorStyles.Left;
-			this.picScaleHelp.BackgroundImage = global::Mesen.GUI.Properties.Resources.Help;
-			this.picScaleHelp.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
-			this.picScaleHelp.Location = new System.Drawing.Point(114, 6);
-			this.picScaleHelp.Margin = new System.Windows.Forms.Padding(3, 5, 3, 3);
-			this.picScaleHelp.Name = "picScaleHelp";
-			this.picScaleHelp.Size = new System.Drawing.Size(16, 16);
-			this.picScaleHelp.TabIndex = 12;
-			this.picScaleHelp.TabStop = false;
-			// 
-			// tableLayoutPanel4
-			// 
-			this.tableLayoutPanel4.ColumnCount = 3;
-			this.tableLayoutPanel1.SetColumnSpan(this.tableLayoutPanel4, 2);
-			this.tableLayoutPanel4.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-			this.tableLayoutPanel4.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-			this.tableLayoutPanel4.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-			this.tableLayoutPanel4.Controls.Add(this.btnSelectFolder, 2, 0);
-			this.tableLayoutPanel4.Controls.Add(this.txtSaveFolder, 1, 0);
-			this.tableLayoutPanel4.Controls.Add(this.lblFolder, 0, 0);
-			this.tableLayoutPanel4.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.tableLayoutPanel4.Location = new System.Drawing.Point(0, 0);
-			this.tableLayoutPanel4.Margin = new System.Windows.Forms.Padding(0);
-			this.tableLayoutPanel4.Name = "tableLayoutPanel4";
-			this.tableLayoutPanel4.RowCount = 1;
-			this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-			this.tableLayoutPanel4.Size = new System.Drawing.Size(499, 29);
-			this.tableLayoutPanel4.TabIndex = 9;
-			// 
-			// btnSelectFolder
-			// 
-			this.btnSelectFolder.AutoSize = true;
-			this.btnSelectFolder.Location = new System.Drawing.Point(434, 3);
-			this.btnSelectFolder.Name = "btnSelectFolder";
-			this.btnSelectFolder.Size = new System.Drawing.Size(62, 23);
-			this.btnSelectFolder.TabIndex = 8;
-			this.btnSelectFolder.Text = "Browse...";
-			this.btnSelectFolder.UseVisualStyleBackColor = true;
-			this.btnSelectFolder.Click += new System.EventHandler(this.btnSelectFolder_Click);
-			// 
-			// txtSaveFolder
-			// 
-			this.txtSaveFolder.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.txtSaveFolder.Location = new System.Drawing.Point(76, 3);
-			this.txtSaveFolder.Name = "txtSaveFolder";
-			this.txtSaveFolder.ReadOnly = true;
-			this.txtSaveFolder.Size = new System.Drawing.Size(352, 20);
-			this.txtSaveFolder.TabIndex = 1;
-			this.txtSaveFolder.TabStop = false;
-			// 
-			// lblFolder
-			// 
-			this.lblFolder.Anchor = System.Windows.Forms.AnchorStyles.Left;
-			this.lblFolder.AutoSize = true;
-			this.lblFolder.Location = new System.Drawing.Point(3, 8);
-			this.lblFolder.Name = "lblFolder";
-			this.lblFolder.Size = new System.Drawing.Size(67, 13);
-			this.lblFolder.TabIndex = 0;
-			this.lblFolder.Text = "Save Folder:";
-			// 
-			// tmrRefresh
-			// 
-			this.tmrRefresh.Interval = 200;
-			this.tmrRefresh.Tick += new System.EventHandler(this.tmrRefresh_Tick);
-			// 
-			// frmHdPackEditor
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(612, 374);
-			this.Controls.Add(this.tableLayoutPanel1);
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-			this.MaximizeBox = false;
-			this.MinimumSize = new System.Drawing.Size(628, 413);
-			this.Name = "frmHdPackEditor";
-			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "HD Pack Builder";
-			this.tableLayoutPanel1.ResumeLayout(false);
-			this.tableLayoutPanel1.PerformLayout();
-			this.grpPreview.ResumeLayout(false);
-			this.tableLayoutPanel3.ResumeLayout(false);
-			this.tableLayoutPanel3.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.picBankPreview)).EndInit();
-			this.grpOptions.ResumeLayout(false);
-			this.tableLayoutPanel2.ResumeLayout(false);
-			this.tableLayoutPanel2.PerformLayout();
-			this.flowLayoutPanel1.ResumeLayout(false);
-			this.flowLayoutPanel1.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.picIgnoreOverscanHelp)).EndInit();
-			this.flowLayoutPanel3.ResumeLayout(false);
-			this.flowLayoutPanel3.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.picGroupBlankHelp)).EndInit();
-			this.flowLayoutPanel4.ResumeLayout(false);
-			this.flowLayoutPanel4.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.picFrequencyHelp)).EndInit();
-			this.flowLayoutPanel5.ResumeLayout(false);
-			this.flowLayoutPanel5.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.picLargeSpritesHelp)).EndInit();
-			this.flpBankSize.ResumeLayout(false);
-			((System.ComponentModel.ISupportInitialize)(this.picBankSizeHelp)).EndInit();
-			this.flowLayoutPanel6.ResumeLayout(false);
-			((System.ComponentModel.ISupportInitialize)(this.picScaleHelp)).EndInit();
-			this.tableLayoutPanel4.ResumeLayout(false);
-			this.tableLayoutPanel4.PerformLayout();
-			this.ResumeLayout(false);
+            this.cboChrBankSize.Location = new System.Drawing.Point(3, 3);
+            this.cboChrBankSize.Name = "cboChrBankSize";
+            this.cboChrBankSize.Size = new System.Drawing.Size(105, 20);
+            this.cboChrBankSize.TabIndex = 4;
+            // 
+            // picBankSizeHelp
+            // 
+            this.picBankSizeHelp.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.picBankSizeHelp.BackgroundImage = global::Mesen.GUI.Properties.Resources.Help;
+            this.picBankSizeHelp.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
+            this.picBankSizeHelp.Location = new System.Drawing.Point(114, 6);
+            this.picBankSizeHelp.Margin = new System.Windows.Forms.Padding(3, 5, 3, 3);
+            this.picBankSizeHelp.Name = "picBankSizeHelp";
+            this.picBankSizeHelp.Size = new System.Drawing.Size(16, 15);
+            this.picBankSizeHelp.TabIndex = 12;
+            this.picBankSizeHelp.TabStop = false;
+            // 
+            // flowLayoutPanel6
+            // 
+            this.flowLayoutPanel6.Controls.Add(this.cboScale);
+            this.flowLayoutPanel6.Controls.Add(this.picScaleHelp);
+            this.flowLayoutPanel6.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel6.Location = new System.Drawing.Point(88, 0);
+            this.flowLayoutPanel6.Margin = new System.Windows.Forms.Padding(0);
+            this.flowLayoutPanel6.Name = "flowLayoutPanel6";
+            this.flowLayoutPanel6.Size = new System.Drawing.Size(237, 22);
+            this.flowLayoutPanel6.TabIndex = 16;
+            // 
+            // cboScale
+            // 
+            this.cboScale.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cboScale.FormattingEnabled = true;
+            this.cboScale.Location = new System.Drawing.Point(3, 3);
+            this.cboScale.Name = "cboScale";
+            this.cboScale.Size = new System.Drawing.Size(105, 20);
+            this.cboScale.TabIndex = 3;
+            // 
+            // picScaleHelp
+            // 
+            this.picScaleHelp.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.picScaleHelp.BackgroundImage = global::Mesen.GUI.Properties.Resources.Help;
+            this.picScaleHelp.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
+            this.picScaleHelp.Location = new System.Drawing.Point(114, 6);
+            this.picScaleHelp.Margin = new System.Windows.Forms.Padding(3, 5, 3, 3);
+            this.picScaleHelp.Name = "picScaleHelp";
+            this.picScaleHelp.Size = new System.Drawing.Size(16, 15);
+            this.picScaleHelp.TabIndex = 12;
+            this.picScaleHelp.TabStop = false;
+            // 
+            // flowLayoutPanel2
+            // 
+            this.tableLayoutPanel2.SetColumnSpan(this.flowLayoutPanel2, 2);
+            this.flowLayoutPanel2.Controls.Add(this.chkSaveFrame);
+            this.flowLayoutPanel2.Controls.Add(this.picSaveFrameHelp);
+            this.flowLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel2.Location = new System.Drawing.Point(0, 122);
+            this.flowLayoutPanel2.Margin = new System.Windows.Forms.Padding(0);
+            this.flowLayoutPanel2.Name = "flowLayoutPanel2";
+            this.flowLayoutPanel2.Size = new System.Drawing.Size(325, 18);
+            this.flowLayoutPanel2.TabIndex = 20;
+            // 
+            // chkSaveFrame
+            // 
+            this.chkSaveFrame.AutoSize = true;
+            this.chkSaveFrame.Location = new System.Drawing.Point(3, 3);
+            this.chkSaveFrame.Name = "chkSaveFrame";
+            this.chkSaveFrame.Size = new System.Drawing.Size(220, 16);
+            this.chkSaveFrame.TabIndex = 9;
+            this.chkSaveFrame.Text = "Save frames which the tiles are first shown";
+            this.chkSaveFrame.UseVisualStyleBackColor = true;
+            // 
+            // picSaveFrameHelp
+            // 
+            this.picSaveFrameHelp.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.picSaveFrameHelp.BackgroundImage = global::Mesen.GUI.Properties.Resources.Help;
+            this.picSaveFrameHelp.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
+            this.picSaveFrameHelp.Location = new System.Drawing.Point(229, 3);
+            this.picSaveFrameHelp.Name = "picSaveFrameHelp";
+            this.picSaveFrameHelp.Size = new System.Drawing.Size(16, 15);
+            this.picSaveFrameHelp.TabIndex = 19;
+            this.picSaveFrameHelp.TabStop = false;
+            // 
+            // tableLayoutPanel4
+            // 
+            this.tableLayoutPanel4.ColumnCount = 3;
+            this.tableLayoutPanel1.SetColumnSpan(this.tableLayoutPanel4, 2);
+            this.tableLayoutPanel4.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel4.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel4.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel4.Controls.Add(this.btnSelectFolder, 2, 0);
+            this.tableLayoutPanel4.Controls.Add(this.txtSaveFolder, 1, 0);
+            this.tableLayoutPanel4.Controls.Add(this.lblFolder, 0, 0);
+            this.tableLayoutPanel4.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel4.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanel4.Margin = new System.Windows.Forms.Padding(0);
+            this.tableLayoutPanel4.Name = "tableLayoutPanel4";
+            this.tableLayoutPanel4.RowCount = 1;
+            this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel4.Size = new System.Drawing.Size(502, 27);
+            this.tableLayoutPanel4.TabIndex = 9;
+            // 
+            // btnSelectFolder
+            // 
+            this.btnSelectFolder.AutoSize = true;
+            this.btnSelectFolder.Location = new System.Drawing.Point(437, 3);
+            this.btnSelectFolder.Name = "btnSelectFolder";
+            this.btnSelectFolder.Size = new System.Drawing.Size(62, 21);
+            this.btnSelectFolder.TabIndex = 2;
+            this.btnSelectFolder.Text = "Browse...";
+            this.btnSelectFolder.UseVisualStyleBackColor = true;
+            this.btnSelectFolder.Click += new System.EventHandler(this.btnSelectFolder_Click);
+            // 
+            // txtSaveFolder
+            // 
+            this.txtSaveFolder.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtSaveFolder.Location = new System.Drawing.Point(72, 3);
+            this.txtSaveFolder.Name = "txtSaveFolder";
+            this.txtSaveFolder.ReadOnly = true;
+            this.txtSaveFolder.Size = new System.Drawing.Size(359, 22);
+            this.txtSaveFolder.TabIndex = 1;
+            this.txtSaveFolder.TabStop = false;
+            // 
+            // lblFolder
+            // 
+            this.lblFolder.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.lblFolder.AutoSize = true;
+            this.lblFolder.Location = new System.Drawing.Point(3, 7);
+            this.lblFolder.Name = "lblFolder";
+            this.lblFolder.Size = new System.Drawing.Size(63, 12);
+            this.lblFolder.TabIndex = 0;
+            this.lblFolder.Text = "Save Folder:";
+            // 
+            // tmrRefresh
+            // 
+            this.tmrRefresh.Interval = 200;
+            this.tmrRefresh.Tick += new System.EventHandler(this.tmrRefresh_Tick);
+            // 
+            // frmHdPackEditor
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 12F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(612, 345);
+            this.Controls.Add(this.tableLayoutPanel1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.MaximizeBox = false;
+            this.MinimumSize = new System.Drawing.Size(628, 384);
+            this.Name = "frmHdPackEditor";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "HD Pack Builder";
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
+            this.grpPreview.ResumeLayout(false);
+            this.tableLayoutPanel3.ResumeLayout(false);
+            this.tableLayoutPanel3.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.picBankPreview)).EndInit();
+            this.grpOptions.ResumeLayout(false);
+            this.tableLayoutPanel2.ResumeLayout(false);
+            this.tableLayoutPanel2.PerformLayout();
+            this.flowLayoutPanel1.ResumeLayout(false);
+            this.flowLayoutPanel1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.picIgnoreOverscanHelp)).EndInit();
+            this.flowLayoutPanel3.ResumeLayout(false);
+            this.flowLayoutPanel3.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.picGroupBlankHelp)).EndInit();
+            this.flowLayoutPanel4.ResumeLayout(false);
+            this.flowLayoutPanel4.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.picFrequencyHelp)).EndInit();
+            this.flowLayoutPanel5.ResumeLayout(false);
+            this.flowLayoutPanel5.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.picLargeSpritesHelp)).EndInit();
+            this.flpBankSize.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.picBankSizeHelp)).EndInit();
+            this.flowLayoutPanel6.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.picScaleHelp)).EndInit();
+            this.flowLayoutPanel2.ResumeLayout(false);
+            this.flowLayoutPanel2.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.picSaveFrameHelp)).EndInit();
+            this.tableLayoutPanel4.ResumeLayout(false);
+            this.tableLayoutPanel4.PerformLayout();
+            this.ResumeLayout(false);
 
 		}
 
@@ -609,5 +652,8 @@
 		private System.Windows.Forms.CheckBox chkIgnoreOverscan;
 		private System.Windows.Forms.PictureBox picIgnoreOverscanHelp;
 		private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
-	}
+	  private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel2;
+	  private System.Windows.Forms.CheckBox chkSaveFrame;
+	  private System.Windows.Forms.PictureBox picSaveFrameHelp;
+   }
 }

--- a/GUI.NET/Forms/HdPackEditor/frmHdPackEditor.cs
+++ b/GUI.NET/Forms/HdPackEditor/frmHdPackEditor.cs
@@ -43,8 +43,9 @@ namespace Mesen.GUI.Forms.HdPackEditor
 			toolTip.SetToolTip(picGroupBlankHelp, ResourceHelper.GetMessage("HdPackBuilderGroupBlankHelp"));
 			toolTip.SetToolTip(picLargeSpritesHelp, ResourceHelper.GetMessage("HdPackBuilderLargeSpritesHelp"));
 			toolTip.SetToolTip(picIgnoreOverscanHelp, ResourceHelper.GetMessage("HdPackBuilderIgnoreOverscanHelp"));
+		   toolTip.SetToolTip(picSaveFrameHelp, ResourceHelper.GetMessage("HdPackBuilderSaveFrameHelp"));
 
-			UpdateUI(false);
+		 UpdateUI(false);
 		}
 
 		protected override void OnFormClosing(FormClosingEventArgs e)
@@ -123,6 +124,8 @@ namespace Mesen.GUI.Forms.HdPackEditor
 			chkLargeSprites.Enabled = !isRecording;
 			chkSortByFrequency.Enabled = !isRecording;
 			chkGroupBlankTiles.Enabled = !isRecording;
+		   chkIgnoreOverscan.Enabled = !isRecording;
+			chkSaveFrame.Enabled = !isRecording;
 
 			cboChrBankSize.Enabled = !isRecording;
 			cboScale.Enabled = !isRecording;
@@ -156,7 +159,10 @@ namespace Mesen.GUI.Forms.HdPackEditor
 			if(chkIgnoreOverscan.Checked) {
 				flags |= HdPackRecordFlags.IgnoreOverscan;
 			}
-			InteropEmu.HdBuilderStartRecording(txtSaveFolder.Text, ((FilterInfo)cboScale.SelectedItem).FilterType, ((FilterInfo)cboScale.SelectedItem).Scale, flags, (UInt32)Math.Pow(2, cboChrBankSize.SelectedIndex) * 0x400);
+		   if(chkSaveFrame.Checked) {
+			   flags |= HdPackRecordFlags.SaveFrame;
+		   }
+		 InteropEmu.HdBuilderStartRecording(txtSaveFolder.Text, ((FilterInfo)cboScale.SelectedItem).FilterType, ((FilterInfo)cboScale.SelectedItem).Scale, flags, (UInt32)Math.Pow(2, cboChrBankSize.SelectedIndex) * 0x400);
 			tmrRefresh.Start();
 
 			UpdateUI(true);

--- a/GUI.NET/Forms/HdPackEditor/frmHdPackEditor.resx
+++ b/GUI.NET/Forms/HdPackEditor/frmHdPackEditor.resx
@@ -121,6 +121,9 @@
     <value>17, 17</value>
   </metadata>
   <metadata name="tmrRefresh.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>107, 17</value>
+    <value>110, 17</value>
+  </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>194</value>
   </metadata>
 </root>

--- a/GUI.NET/InteropEmu.cs
+++ b/GUI.NET/InteropEmu.cs
@@ -2548,9 +2548,10 @@ namespace Mesen.GUI
 		SortByUsageFrequency = 2,
 		GroupBlankTiles = 4,
 		IgnoreOverscan = 8,
-	}
+	   SaveFrame = 16,
+   }
 
-	[StructLayout(LayoutKind.Sequential)]
+   [StructLayout(LayoutKind.Sequential)]
 	public class AddressTypeInfo
 	{
 		public Int32 Address;


### PR DESCRIPTION
Added an option in HD pack builder to save screen information when tiles are first shown in the same folder as the HD pack. User can look up which screen the tiles are added in the tileIndex.csv and open the screen_XXX.csv and screen_XXX.png to see the actual usage of the tiles.

Added playback option and volume option to <bgm> tag as suggested by kya. Use 1 for looping playback, 0 for single playback, -1 for no change to playback option. Use 0 to 255 for volume control and -1 for no volume change:
<bgm>[album - integer],[track - integer],[filename - ogg],[loop point - integer],[playback option - integer],[volume - integer]