### PR TITLE
Fix CPU::StreamState extraScanlinesAfterNmi argument

### DIFF
--- a/Core/CPU.cpp
+++ b/Core/CPU.cpp
@@ -476,7 +476,7 @@ void CPU::StreamState(bool saving)
 
 	Stream(_state.PC, _state.SP, _state.PS, _state.A, _state.X, _state.Y, _cycleCount, _state.NMIFlag, 
 			_state.IRQFlag, _dmcDmaRunning, _spriteDmaTransfer,
-			extraScanlinesBeforeNmi, extraScanlinesBeforeNmi, dipSwitches,
+			extraScanlinesBeforeNmi, extraScanlinesAfterNmi, dipSwitches,
 			_needDummyRead, _needHalt, _startClockCount, _endClockCount, _ppuOffset, _masterClock,
 			_prevNeedNmi, _prevNmiFlag, _needNmi);
 


### PR DESCRIPTION
Previously the CPU::StreamState function passed the extraScanlines**Before**Nmi value twice to Stream. Change the second argument to extraScanlines**After**Nmi instead.

This could affect netplay, save states, and the history viewer, but I'm not familiar enough with the Mesen codebase to say what the  effects would be. Since the default value is 0 for extra scanlines before and after NMI, and has a general warning that changing these values could cause issues, I doubt the behavior would change for most users' configuration. I don't think this change would have any effect on loading existing save states.