### PR TITLE
Renaming EPSG to EPSM, changing NSF header bit and adding 401C-401F addressing to all mappers. 

### DIFF
--- a/Core/BaseMapper.cpp
+++ b/Core/BaseMapper.cpp
@@ -14,7 +14,7 @@
 #include "CPU.h"
 
 void BaseMapper::WriteRegister(uint16_t addr, uint8_t value) { }
-void BaseMapper::WriteEPSG(uint16_t addr, uint8_t value) { _epsgaudio->WriteRegister(addr, value); }
+void BaseMapper::WriteEPSM(uint16_t addr, uint8_t value) { _epsmaudio->WriteRegister(addr, value); }
 uint8_t BaseMapper::ReadRegister(uint16_t addr) { return 0; }
 void BaseMapper::InitMapper(RomData &romData) { }
 void BaseMapper::Reset(bool softReset) { }
@@ -510,9 +510,9 @@ void BaseMapper::StreamState(bool saving)
 	ArrayInfo<ChrMemoryType> chrMemoryType = { _chrMemoryType, 0x40 };
 	ArrayInfo<MemoryAccessType> prgMemoryAccess = { _prgMemoryAccess, 0x100 };
 	ArrayInfo<MemoryAccessType> chrMemoryAccess = { _chrMemoryAccess, 0x40 };
-	SnapshotInfo epsgaudio{ _epsgaudio.get() };
+	SnapshotInfo epsmaudio{ _epsmaudio.get() };
 
-	Stream(_mirroringType, chrRam, workRam, saveRam, nametableRam, prgMemoryOffset, chrMemoryOffset, prgMemoryType, chrMemoryType, prgMemoryAccess, chrMemoryAccess, epsgaudio);
+	Stream(_mirroringType, chrRam, workRam, saveRam, nametableRam, prgMemoryOffset, chrMemoryOffset, prgMemoryType, chrMemoryType, prgMemoryAccess, chrMemoryAccess, epsmaudio);
 
 	if(!saving) {
 		RestorePrgChrState();
@@ -639,7 +639,7 @@ void BaseMapper::Initialize(RomData &romData)
 
 	InitMapper();
 	InitMapper(romData);
-	_epsgaudio.reset(new EPSGAudio(_console));
+	_epsmaudio.reset(new EPSMAudio(_console));
 
 	//Load battery data if present
 	LoadBattery();
@@ -782,7 +782,7 @@ uint8_t BaseMapper::DebugReadRAM(uint16_t addr)
 
 void BaseMapper::WriteRAM(uint16_t addr, uint8_t value)
 {
-	if((addr == 0x4016) & (_console->GetCpu()->GetCycleCount() % 2 == 1)){ WriteEPSG(addr, value); }
+	if((addr == 0x4016) & (_console->GetCpu()->GetCycleCount() % 2 == 1)){ WriteEPSM(addr, value); }
 	if(_isWriteRegisterAddr[addr]) {
 		if(_hasBusConflicts) {
 			uint8_t prgValue = _prgPages[addr >> 8][(uint8_t)addr];

--- a/Core/BaseMapper.cpp
+++ b/Core/BaseMapper.cpp
@@ -783,6 +783,7 @@ uint8_t BaseMapper::DebugReadRAM(uint16_t addr)
 void BaseMapper::WriteRAM(uint16_t addr, uint8_t value)
 {
 	if((addr == 0x4016) & (_console->GetCpu()->GetCycleCount() % 2 == 1)){ WriteEPSM(addr, value); }
+	if ((addr >= 0x401c && addr <= 0x401f)) { WriteEPSM(addr, value); }
 	if(_isWriteRegisterAddr[addr]) {
 		if(_hasBusConflicts) {
 			uint8_t prgValue = _prgPages[addr >> 8][(uint8_t)addr];

--- a/Core/BaseMapper.h
+++ b/Core/BaseMapper.h
@@ -10,7 +10,7 @@
 #include "RomData.h"
 #include "Console.h"
 #include "CPU.h"
-#include "EPSGAudio.h"
+#include "EPSMAudio.h"
 
 class BaseControlDevice;
 
@@ -106,7 +106,7 @@ protected:
 	uint8_t InternalReadRam(uint16_t addr);
 
 	virtual void WriteRegister(uint16_t addr, uint8_t value);
-	virtual void WriteEPSG(uint16_t addr, uint8_t value);
+	virtual void WriteEPSM(uint16_t addr, uint8_t value);
 	virtual uint8_t ReadRegister(uint16_t addr);
 
 	void SelectPrgPage4x(uint16_t slot, uint16_t page, PrgMemoryType memoryType = PrgMemoryType::PrgRom);
@@ -158,7 +158,7 @@ protected:
 public:
 	static constexpr uint32_t NametableCount = 0x10;
 	static constexpr uint32_t NametableSize = 0x400;
-	unique_ptr<EPSGAudio> _epsgaudio;
+	unique_ptr<EPSMAudio> _epsmaudio;
 	void Initialize(RomData &romData);
 
 	virtual ~BaseMapper();
@@ -168,7 +168,7 @@ public:
 
 	virtual void SetNesModel(NesModel model) { }
 	virtual void ProcessCpuClock() { }
-	virtual void ProcessEPSGClock() { _epsgaudio->Clock(); }
+	virtual void ProcessEPSMClock() { _epsmaudio->Clock(); }
 	virtual void NotifyVRAMAddressChange(uint16_t addr);
 	virtual void GetMemoryRanges(MemoryRanges &ranges) override;
 	

--- a/Core/Console.cpp
+++ b/Core/Console.cpp
@@ -465,7 +465,7 @@ bool Console::Initialize(VirtualFile &romFile, VirtualFile &patchFile, bool forP
 
 void Console::ProcessCpuClock()
 {
-	_mapper->ProcessEPSGClock();
+	_mapper->ProcessEPSMClock();
 	_mapper->ProcessCpuClock();
 	_apu->ProcessCpuClock();
 }

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -559,7 +559,7 @@
     <ClInclude Include="Eeprom24C01.h" />
     <ClInclude Include="Eeprom24C02.h" />
     <ClInclude Include="emu2149.h" />
-    <ClInclude Include="EPSGAudio.h" />
+    <ClInclude Include="EPSMAudio.h" />
     <ClInclude Include="EventManager.h" />
     <ClInclude Include="FaridSlrom.h" />
     <ClInclude Include="FaridUnrom.h" />

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -1508,9 +1508,6 @@
     <ClInclude Include="ym3438.h">
       <Filter>Nes\Mappers\EPSG</Filter>
     </ClInclude>
-    <ClInclude Include="EPSGAudio.h">
-      <Filter>Nes\Mappers\EPSG</Filter>
-    </ClInclude>
     <ClInclude Include="SSGAudio.h">
       <Filter>Nes\Mappers</Filter>
     </ClInclude>
@@ -1518,6 +1515,9 @@
       <Filter>Nes\Mappers\VRC</Filter>
     </ClInclude>
     <ClInclude Include="emu2149.h">
+      <Filter>Nes\Mappers\EPSG</Filter>
+    </ClInclude>
+    <ClInclude Include="EPSMAudio.h">
       <Filter>Nes\Mappers\EPSG</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Core/EPSMAudio.h
+++ b/Core/EPSMAudio.h
@@ -177,6 +177,10 @@ public:
 				WriteToChip(a04016 | (a14016 << 1), writeValue);
 			}
 		}
+		if (addr == 0x401c) { addr = 0xC000; }
+		if (addr == 0x401d) { addr = 0xE000; }
+		if (addr == 0x401e) { addr = 0xC002; }
+		if (addr == 0x401f) { addr = 0xE002; }
 
 		switch(addr) {
 			case 0xC000:

--- a/Core/EPSMAudio.h
+++ b/Core/EPSMAudio.h
@@ -9,9 +9,9 @@
 #include <array>
 #include "ym3438.h"
 
-using EPSGSSGAudio = SSGAudio<AudioChannel::EPSG_L, AudioChannel::EPSG_R>;
+using EPSMSSGAudio = SSGAudio<AudioChannel::EPSM_L, AudioChannel::EPSM_R>;
 
-class EPSGAudio : public EPSGSSGAudio
+class EPSMAudio : public EPSMSSGAudio
 {
 private:
 	ym3438_t _chip;
@@ -42,7 +42,7 @@ private:
 		int16_t summedOutput = 0;
 		for (size_t x = 0; x < 2; x++)
 		{
-			_console->GetApu()->AddExpansionAudioDelta(x == 0 ? AudioChannel::EPSG_L : AudioChannel::EPSG_R, _currentOutputs[x] - _lastOutputs[x]);
+			_console->GetApu()->AddExpansionAudioDelta(x == 0 ? AudioChannel::EPSM_L : AudioChannel::EPSM_R, _currentOutputs[x] - _lastOutputs[x]);
 			_lastOutputs[x] = _currentOutputs[x];
 		}
 	}
@@ -58,7 +58,7 @@ private:
 
 		if (_inputBuffer[cycle].wrote)
 		{
-			std::cout << "EPSG CHIP DOUBLE WRITE" << std::endl;
+			std::cout << "EPSM CHIP DOUBLE WRITE" << std::endl;
 		}
 
 		_inputBuffer[cycle] = {
@@ -71,13 +71,13 @@ private:
 
 	uint32_t getClockFrequency()
 	{
-		return _console->GetSettings()->GetEPSGClockFrequency() / 6;
+		return _console->GetSettings()->GetEPSMClockFrequency() / 6;
 	}
 
 protected:
 	void StreamState(bool saving) override
 	{
-		EPSGSSGAudio::StreamState(saving);
+		EPSMSSGAudio::StreamState(saving);
 
 		ArrayInfo<int16_t> lastOutputs{ _lastOutputs, 2 };
 		ArrayInfo<int16_t> currentOutputs{ _currentOutputs, 2 };
@@ -89,7 +89,7 @@ protected:
 
 	void ClockAudio() override
 	{
-		EPSGSSGAudio::ClockAudio();
+		EPSMSSGAudio::ClockAudio();
 
 		_clock += getClockFrequency() / (double)_console->GetCpu()->GetClockRate(_console->GetModel());
 
@@ -132,11 +132,11 @@ protected:
 
 	virtual uint32_t GetSSGClockFrequency()
 	{
-		return EPSGSSGAudio::GetSSGClockFrequency() * (_console->GetSettings()->GetEPSGClockFrequency() / 3579545.0 );
+		return EPSMSSGAudio::GetSSGClockFrequency() * (_console->GetSettings()->GetEPSMClockFrequency() / 3579545.0 );
 	}
 
 public:
-	EPSGAudio(shared_ptr<Console> console) : EPSGSSGAudio(console)
+	EPSMAudio(shared_ptr<Console> console) : EPSMSSGAudio(console)
 	{
 		memset(_lastOutputs, 0, sizeof(_lastOutputs));
 		memset(_currentOutputs, 0, sizeof(_currentOutputs));
@@ -173,7 +173,7 @@ public:
 
 				const uint8_t a04016 = (writeAddr & 0xF000) == 0xE000;
 				const uint8_t a14016 = !!(writeAddr & 0xF);
-				EPSGSSGAudio::WriteRegister(writeAddr, writeValue);
+				EPSMSSGAudio::WriteRegister(writeAddr, writeValue);
 				WriteToChip(a04016 | (a14016 << 1), writeValue);
 			}
 		}
@@ -186,7 +186,7 @@ public:
 
 				const uint8_t a0 = (addr & 0xF000) == 0xE000;
 				const uint8_t a1 = !!(addr & 0xF);
-				EPSGSSGAudio::WriteRegister(addr, value);
+				EPSMSSGAudio::WriteRegister(addr, value);
 				WriteToChip(a0 | (a1 << 1), value);
 
 				break;

--- a/Core/EmulationSettings.h
+++ b/Core/EmulationSettings.h
@@ -117,8 +117,8 @@ enum class AudioChannel
 	VRC7 = 8,
 	Namco163 = 9,
 	Sunsoft5B = 10,
-	EPSG_L = 11,
-	EPSG_R = 12,
+	EPSM_L = 11,
+	EPSM_R = 12,
 };
 
 enum class EqualizerFilterType
@@ -659,7 +659,7 @@ private:
 	
 	bool _audioSettingsChanged = false;
 	uint32_t _audioLatency = 50;
-	uint32_t _EPSGClockFrequency = 3579545;
+	uint32_t _EPSMClockFrequency = 3579545;
 	double _channelVolume[13] = { 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0 };
 	double _channelPanning[13] = { 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 2.0 };
 	EqualizerFilterType _equalizerFilterType = EqualizerFilterType::None;
@@ -990,9 +990,9 @@ public:
 		_audioSettingsChanged = true;
 	}
 
-	void SetEPSGClockFrequency(uint32_t clockFrequency)
+	void SetEPSMClockFrequency(uint32_t clockFrequency)
 	{
-		_EPSGClockFrequency = clockFrequency;
+		_EPSMClockFrequency = clockFrequency;
 		_audioSettingsChanged = true;
 	}
 
@@ -1167,9 +1167,9 @@ public:
 		return _audioLatency;
 	}
 
-	uint32_t GetEPSGClockFrequency()
+	uint32_t GetEPSMClockFrequency()
 	{
-		return _EPSGClockFrequency;
+		return _EPSMClockFrequency;
 	}
 
 	void SetVideoFilterType(VideoFilterType videoFilterType)

--- a/Core/MemoryManager.cpp
+++ b/Core/MemoryManager.cpp
@@ -133,7 +133,7 @@ void MemoryManager::Write(uint16_t addr, uint8_t value, MemoryOperationType oper
 {
 	if(_console->DebugProcessRamOperation(operationType, addr, value)) {
 		_ramWriteHandlers[addr]->WriteRAM(addr, value);
-		if (addr == 0x4016) {
+		if ((addr == 0x4016) | (addr >= 0x401c && addr <= 0x401f)) {
 			_ramWriteHandlers[0xE000]->WriteRAM(addr, value);
 		}
 	}

--- a/Core/NsfLoader.cpp
+++ b/Core/NsfLoader.cpp
@@ -90,8 +90,8 @@ void NsfLoader::InitializeFromHeader(RomData &romData)
 	if (header.SoundChips & 0x20) {
 		chips.push_back("Sunsoft 5B");
 	}
-	if (header.SoundChips & 0x40) {
-		chips.push_back("EPSG");
+	if (header.SoundChips & 0x80) {
+		chips.push_back("EPSM");
 	}
 	if(chips.empty()) {
 		chips.push_back("<none>");

--- a/Core/NsfLoader.cpp
+++ b/Core/NsfLoader.cpp
@@ -90,6 +90,9 @@ void NsfLoader::InitializeFromHeader(RomData &romData)
 	if (header.SoundChips & 0x20) {
 		chips.push_back("Sunsoft 5B");
 	}
+	if (header.SoundChips & 0x40) {
+		chips.push_back("VT02");
+	}
 	if (header.SoundChips & 0x80) {
 		chips.push_back("EPSM");
 	}

--- a/Core/NsfMapper.cpp
+++ b/Core/NsfMapper.cpp
@@ -27,7 +27,7 @@ void NsfMapper::InitMapper()
 	_fdsAudio.reset(new FdsAudio(_console));
 	_namcoAudio.reset(new Namco163Audio(_console));
 	_sunsoftAudio.reset(new Sunsoft5bAudio(_console));
-	_epsgAudio.reset(new EPSGAudio(_console));
+	_epsmAudio.reset(new EPSMAudio(_console));
 
 	SetCpuMemoryMapping(0x3F00, 0x3FFF, PrgMemoryType::WorkRam, 0x2000, MemoryAccessType::Read);
 	memcpy(GetWorkRam() + 0x2000, _nsfBios, 0x100);
@@ -109,8 +109,9 @@ void NsfMapper::InitMapper(RomData& romData)
 		AddRegisterRange(0x4040, 0x4092, MemoryOperation::Any);
 	}
 
-	if(_nsfHeader.SoundChips & NsfSoundChips::EPSG) {
+	if(_nsfHeader.SoundChips & NsfSoundChips::EPSM) {
 		AddRegisterRange(0x4016, 0x4016, MemoryOperation::Write);
+		AddRegisterRange(0xC000, 0xFFFF, MemoryOperation::Write);
 	}
 }
 
@@ -277,8 +278,8 @@ void NsfMapper::ProcessCpuClock()
 	if(_nsfHeader.SoundChips & NsfSoundChips::FDS) {
 		_fdsAudio->Clock();
 	}
-	if (_nsfHeader.SoundChips & NsfSoundChips::EPSG) {
-		_epsgAudio->Clock();
+	if (_nsfHeader.SoundChips & NsfSoundChips::EPSM) {
+		_epsmAudio->Clock();
 	}
 }
 
@@ -358,7 +359,11 @@ void NsfMapper::WriteRegister(uint16_t addr, uint8_t value)
 		}*/
 	} else if((_nsfHeader.SoundChips & NsfSoundChips::Sunsoft) && addr >= 0xC000 && addr <= 0xFFFF) {
 		_sunsoftAudio->WriteRegister(addr, value);
-	} else {
+	}
+		else if ((_nsfHeader.SoundChips & NsfSoundChips::EPSM) && addr >= 0xC000 && addr <= 0xFFFF) {
+		_epsmAudio->WriteRegister(addr, value);
+	}
+	else {
 		switch(addr) {
 			case 0x3E10: _irqReloadValue = (_irqReloadValue & 0xFF00) | value; break;
 			case 0x3E11: _irqReloadValue = (_irqReloadValue & 0xFF) | (value << 8); break;
@@ -409,7 +414,7 @@ void NsfMapper::WriteRegister(uint16_t addr, uint8_t value)
 				break;
 
 			case 0x4016:
-				_epsgAudio->WriteRegister(addr, value);
+				_epsmAudio->WriteRegister(addr, value);
 				break;
 
 		}
@@ -490,11 +495,11 @@ void NsfMapper::StreamState(bool saving)
 	SnapshotInfo fdsAudio { _fdsAudio.get() };
 	SnapshotInfo namcoAudio { _namcoAudio.get() };
 	SnapshotInfo sunsoftAudio { _sunsoftAudio.get() };
-	SnapshotInfo epsgAudio{ _epsgAudio.get() };
+	SnapshotInfo epsmAudio{ _epsmAudio.get() };
 
 	Stream(
 		_model, _needInit, _irqEnabled, _irqReloadValue, _irqCounter, _irqStatus, _debugIrqStatus, _mmc5MultiplierValues[0], _mmc5MultiplierValues[1],
 		_trackEndCounter, _trackFadeCounter, _fadeLength, _silenceDetectDelay, _trackEnded, _allowSilenceDetection, _hasBankSwitching, _ntscSpeed,
-		_palSpeed, _dendySpeed, _songNumber, mmc5Audio, vrc6Audio, vrc7Audio, fdsAudio, namcoAudio, sunsoftAudio, epsgAudio
+		_palSpeed, _dendySpeed, _songNumber, mmc5Audio, vrc6Audio, vrc7Audio, fdsAudio, namcoAudio, sunsoftAudio, epsmAudio
 	);
 }

--- a/Core/NsfMapper.cpp
+++ b/Core/NsfMapper.cpp
@@ -111,7 +111,7 @@ void NsfMapper::InitMapper(RomData& romData)
 
 	if(_nsfHeader.SoundChips & NsfSoundChips::EPSM) {
 		AddRegisterRange(0x4016, 0x4016, MemoryOperation::Write);
-		AddRegisterRange(0xC000, 0xFFFF, MemoryOperation::Write);
+		AddRegisterRange(0x401c, 0x401f, MemoryOperation::Write);
 	}
 }
 
@@ -360,7 +360,7 @@ void NsfMapper::WriteRegister(uint16_t addr, uint8_t value)
 	} else if((_nsfHeader.SoundChips & NsfSoundChips::Sunsoft) && addr >= 0xC000 && addr <= 0xFFFF) {
 		_sunsoftAudio->WriteRegister(addr, value);
 	}
-		else if ((_nsfHeader.SoundChips & NsfSoundChips::EPSM) && addr >= 0xC000 && addr <= 0xFFFF) {
+		else if ((_nsfHeader.SoundChips & NsfSoundChips::EPSM) && addr >= 0x401C && addr <= 0x401F) {
 		_epsmAudio->WriteRegister(addr, value);
 	}
 	else {
@@ -495,11 +495,11 @@ void NsfMapper::StreamState(bool saving)
 	SnapshotInfo fdsAudio { _fdsAudio.get() };
 	SnapshotInfo namcoAudio { _namcoAudio.get() };
 	SnapshotInfo sunsoftAudio { _sunsoftAudio.get() };
-	SnapshotInfo epsmAudio{ _epsmAudio.get() };
+	SnapshotInfo epsgAudio{ _epsmAudio.get() };
 
 	Stream(
 		_model, _needInit, _irqEnabled, _irqReloadValue, _irqCounter, _irqStatus, _debugIrqStatus, _mmc5MultiplierValues[0], _mmc5MultiplierValues[1],
 		_trackEndCounter, _trackFadeCounter, _fadeLength, _silenceDetectDelay, _trackEnded, _allowSilenceDetection, _hasBankSwitching, _ntscSpeed,
-		_palSpeed, _dendySpeed, _songNumber, mmc5Audio, vrc6Audio, vrc7Audio, fdsAudio, namcoAudio, sunsoftAudio, epsmAudio
+		_palSpeed, _dendySpeed, _songNumber, mmc5Audio, vrc6Audio, vrc7Audio, fdsAudio, namcoAudio, sunsoftAudio, epsgAudio
 	);
 }

--- a/Core/NsfMapper.h
+++ b/Core/NsfMapper.h
@@ -27,6 +27,7 @@ private:
 		MMC5 = 0x08,
 		Namco = 0x10,
 		Sunsoft = 0x20,
+		VT02 = 0x40,
 		EPSM = 0x80
 	};
 

--- a/Core/NsfMapper.h
+++ b/Core/NsfMapper.h
@@ -6,7 +6,7 @@
 #include "FdsAudio.h"
 #include "Namco163Audio.h"
 #include "Sunsoft5bAudio.h"
-#include "EPSGAudio.h"
+#include "EPSMAudio.h"
 
 enum class NsfIrqType
 {
@@ -27,7 +27,7 @@ private:
 		MMC5 = 0x08,
 		Namco = 0x10,
 		Sunsoft = 0x20,
-		EPSG = 0x40
+		EPSM = 0x80
 	};
 
 	NesModel _model;
@@ -39,7 +39,7 @@ private:
 	unique_ptr<FdsAudio> _fdsAudio;
 	unique_ptr<Namco163Audio> _namcoAudio;
 	unique_ptr<Sunsoft5bAudio> _sunsoftAudio;
-	unique_ptr<EPSGAudio> _epsgAudio;
+	unique_ptr<EPSMAudio> _epsmAudio;
 	
 	bool _needInit = false;
 	bool _irqEnabled = false;

--- a/Core/SoundMixer.cpp
+++ b/Core/SoundMixer.cpp
@@ -275,8 +275,8 @@ int16_t SoundMixer::GetOutputVolume(bool forRightChannel)
 #else
 		GetChannelOutput(AudioChannel::VRC7, forRightChannel) +
 #endif
-		GetChannelOutput(AudioChannel::EPSG_L, forRightChannel) * 4 +
-		GetChannelOutput(AudioChannel::EPSG_R, forRightChannel) * 4
+		GetChannelOutput(AudioChannel::EPSM_L, forRightChannel) * 4 +
+		GetChannelOutput(AudioChannel::EPSM_R, forRightChannel) * 4
 	);
 }
 

--- a/GUI.NET/Config/AudioInfo.cs
+++ b/GUI.NET/Config/AudioInfo.cs
@@ -6,7 +6,7 @@ namespace Mesen.GUI.Config
 	{
 		public string AudioDevice = "";
 		public bool EnableAudio = true;
-		public bool EnableEPSG = true;
+		public bool EnableEPSM = true;
 
 		public bool DisableDynamicSampleRate = false;
 
@@ -24,10 +24,10 @@ namespace Mesen.GUI.Config
 		[MinMax(0, 100)] public UInt32 Vrc7Volume = 100;
 		[MinMax(0, 100)] public UInt32 Namco163Volume = 100;
 		[MinMax(0, 100)] public UInt32 Sunsoft5bVolume = 100;
-		[MinMax(0, 100)] public UInt32 EPSGVolume_L = 50;
-		[MinMax(0, 100)] public UInt32 EPSGVolume_R = 50;
+		[MinMax(0, 100)] public UInt32 EPSMVolume_L = 50;
+		[MinMax(0, 100)] public UInt32 EPSMVolume_R = 50;
 
-		[MinMax(10000, 32000000)] public UInt32 EPSGClockFrequency = 3579545;
+		[MinMax(10000, 32000000)] public UInt32 EPSMClockFrequency = 3579545;
 
 		[MinMax(-100, 100)] public Int32 Square1Panning = 0;
 		[MinMax(-100, 100)] public Int32 Square2Panning = 0;
@@ -40,8 +40,8 @@ namespace Mesen.GUI.Config
 		[MinMax(-100, 100)] public Int32 Vrc7Panning = 0;
 		[MinMax(-100, 100)] public Int32 Namco163Panning = 0;
 		[MinMax(-100, 100)] public Int32 Sunsoft5bPanning = 0;
-		[MinMax(-100, 100)] public Int32 EPSGPanning_L = -100;
-		[MinMax(-100, 100)] public Int32 EPSGPanning_R = 100;
+		[MinMax(-100, 100)] public Int32 EPSMPanning_L = -100;
+		[MinMax(-100, 100)] public Int32 EPSMPanning_R = 100;
 
 		[ValidValues(11025, 22050, 44100, 48000, 96000)] public UInt32 SampleRate = 48000;
 		public bool ReduceSoundInBackground = true;
@@ -121,10 +121,10 @@ namespace Mesen.GUI.Config
 			InteropEmu.SetChannelVolume(AudioChannel.VRC7, ConvertVolume(audioInfo.Vrc7Volume));
 			InteropEmu.SetChannelVolume(AudioChannel.Namco163, ConvertVolume(audioInfo.Namco163Volume));
 			InteropEmu.SetChannelVolume(AudioChannel.Sunsoft5B, ConvertVolume(audioInfo.Sunsoft5bVolume));
-			InteropEmu.SetChannelVolume(AudioChannel.EPSG_L, ConvertVolume(audioInfo.EPSGVolume_L));
-			InteropEmu.SetChannelVolume(AudioChannel.EPSG_R, ConvertVolume(audioInfo.EPSGVolume_R));
-			InteropEmu.SetChannelVolume(AudioChannel.EPSG_L, audioInfo.EnableEPSG ? AudioInfo.ConvertVolume(audioInfo.EPSGVolume_L) : 0);
-			InteropEmu.SetChannelVolume(AudioChannel.EPSG_R, audioInfo.EnableEPSG ? AudioInfo.ConvertVolume(audioInfo.EPSGVolume_R) : 0);
+			InteropEmu.SetChannelVolume(AudioChannel.EPSM_L, ConvertVolume(audioInfo.EPSMVolume_L));
+			InteropEmu.SetChannelVolume(AudioChannel.EPSM_R, ConvertVolume(audioInfo.EPSMVolume_R));
+			InteropEmu.SetChannelVolume(AudioChannel.EPSM_L, audioInfo.EnableEPSM ? AudioInfo.ConvertVolume(audioInfo.EPSMVolume_L) : 0);
+			InteropEmu.SetChannelVolume(AudioChannel.EPSM_R, audioInfo.EnableEPSM ? AudioInfo.ConvertVolume(audioInfo.EPSMVolume_R) : 0);
 
 			InteropEmu.SetChannelPanning(AudioChannel.Square1, ConvertPanning(audioInfo.Square1Panning));
 			InteropEmu.SetChannelPanning(AudioChannel.Square2, ConvertPanning(audioInfo.Square2Panning));
@@ -137,10 +137,10 @@ namespace Mesen.GUI.Config
 			InteropEmu.SetChannelPanning(AudioChannel.VRC7, ConvertPanning(audioInfo.Vrc7Panning));
 			InteropEmu.SetChannelPanning(AudioChannel.Namco163, ConvertPanning(audioInfo.Namco163Panning));
 			InteropEmu.SetChannelPanning(AudioChannel.Sunsoft5B, ConvertPanning(audioInfo.Sunsoft5bPanning));
-			InteropEmu.SetChannelPanning(AudioChannel.EPSG_L, ConvertPanning(audioInfo.EPSGPanning_L));
-			InteropEmu.SetChannelPanning(AudioChannel.EPSG_R, ConvertPanning(audioInfo.EPSGPanning_R));
+			InteropEmu.SetChannelPanning(AudioChannel.EPSM_L, ConvertPanning(audioInfo.EPSMPanning_L));
+			InteropEmu.SetChannelPanning(AudioChannel.EPSM_R, ConvertPanning(audioInfo.EPSMPanning_R));
 
-			InteropEmu.SetEPSGClockFrequency(audioInfo.EPSGClockFrequency);
+			InteropEmu.SetEPSMClockFrequency(audioInfo.EPSMClockFrequency);
 
 			InteropEmu.SetEqualizerFilterType(audioInfo.EnableEqualizer ? audioInfo.EqualizerFilterType : EqualizerFilterType.None);
 

--- a/GUI.NET/Controls/ctrlNsfPlayer.Designer.cs
+++ b/GUI.NET/Controls/ctrlNsfPlayer.Designer.cs
@@ -46,7 +46,7 @@
 			this.lblSunsoft = new System.Windows.Forms.Label();
 			this.lblVrc6 = new System.Windows.Forms.Label();
 			this.lblVrc7 = new System.Windows.Forms.Label();
-			this.lblEpsg = new System.Windows.Forms.Label();
+			this.lblEpsm = new System.Windows.Forms.Label();
 			this.lblSoundChips = new System.Windows.Forms.Label();
 			this.trkVolume = new System.Windows.Forms.TrackBar();
 			this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
@@ -268,7 +268,7 @@
 			this.tableLayoutPanel3.Controls.Add(this.lblSunsoft, 3, 0);
 			this.tableLayoutPanel3.Controls.Add(this.lblVrc6, 4, 0);
 			this.tableLayoutPanel3.Controls.Add(this.lblVrc7, 5, 0);
-			this.tableLayoutPanel3.Controls.Add(this.lblEpsg, 6, 0);
+			this.tableLayoutPanel3.Controls.Add(this.lblEpsm, 6, 0);
 			this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
 			this.tableLayoutPanel3.Location = new System.Drawing.Point(101, 66);
 			this.tableLayoutPanel3.Name = "tableLayoutPanel3";
@@ -357,18 +357,18 @@
 			this.lblVrc7.TabIndex = 3;
 			this.lblVrc7.Text = "VRC7";
 			// 
-			// lblEpsg
+			// lblEpsm
 			// 
-			this.lblEpsg.AutoSize = true;
-			this.lblEpsg.BackColor = System.Drawing.Color.Transparent;
-			this.lblEpsg.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.lblEpsg.ForeColor = System.Drawing.Color.White;
-			this.lblEpsg.Location = new System.Drawing.Point(220, 0);
-			this.lblEpsg.Margin = new System.Windows.Forms.Padding(0);
-			this.lblEpsg.Name = "lblEpsg";
-			this.lblEpsg.Size = new System.Drawing.Size(35, 13);
-			this.lblEpsg.TabIndex = 3;
-			this.lblEpsg.Text = "EPSM";
+			this.lblEpsm.AutoSize = true;
+			this.lblEpsm.BackColor = System.Drawing.Color.Transparent;
+			this.lblEpsm.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.lblEpsm.ForeColor = System.Drawing.Color.White;
+			this.lblEpsm.Location = new System.Drawing.Point(220, 0);
+			this.lblEpsm.Margin = new System.Windows.Forms.Padding(0);
+			this.lblEpsm.Name = "lblEpsm";
+			this.lblEpsm.Size = new System.Drawing.Size(35, 13);
+			this.lblEpsm.TabIndex = 3;
+			this.lblEpsm.Text = "EPSM";
 			// 
 			// lblSoundChips
 			// 
@@ -743,7 +743,7 @@
 		private System.Windows.Forms.Label lblSunsoft;
 		private System.Windows.Forms.Label lblVrc6;
 		private System.Windows.Forms.Label lblVrc7;
-		private System.Windows.Forms.Label lblEpsg;
+		private System.Windows.Forms.Label lblEpsm;
 		private System.Windows.Forms.Label lblMmc5;
 		private System.Windows.Forms.Label lblNamco;
 		private System.Windows.Forms.Label lblFds;

--- a/GUI.NET/Controls/ctrlNsfPlayer.Designer.cs
+++ b/GUI.NET/Controls/ctrlNsfPlayer.Designer.cs
@@ -368,7 +368,7 @@
 			this.lblEpsg.Name = "lblEpsg";
 			this.lblEpsg.Size = new System.Drawing.Size(35, 13);
 			this.lblEpsg.TabIndex = 3;
-			this.lblEpsg.Text = "EPSG";
+			this.lblEpsg.Text = "EPSM";
 			// 
 			// lblSoundChips
 			// 

--- a/GUI.NET/Controls/ctrlNsfPlayer.cs
+++ b/GUI.NET/Controls/ctrlNsfPlayer.cs
@@ -274,7 +274,7 @@ namespace Mesen.GUI.Controls
 					lblMmc5.ForeColor = (header.SoundChips & 0x08) == 0x08 ? Color.White : Color.Gray;
 					lblNamco.ForeColor = (header.SoundChips & 0x10) == 0x10 ? Color.White : Color.Gray;
 					lblSunsoft.ForeColor = (header.SoundChips & 0x20) == 0x20 ? Color.White : Color.Gray;
-					lblEpsg.ForeColor = (header.SoundChips & 0x40) == 0x40 ? Color.White : Color.Gray;
+					lblEpsm.ForeColor = (header.SoundChips & 0x80) == 0x80 ? Color.White : Color.Gray;
 
 					if (InteropEmu.IsPaused()) {
 						btnPause.Image = Properties.Resources.Play;

--- a/GUI.NET/Debugger/frmApuViewer.Designer.cs
+++ b/GUI.NET/Debugger/frmApuViewer.Designer.cs
@@ -41,7 +41,7 @@
 			this.chkVrc7 = new System.Windows.Forms.CheckBox();
 			this.chkDmc = new System.Windows.Forms.CheckBox();
 			this.chkSunsoft = new System.Windows.Forms.CheckBox();
-			this.chkEPSG = new System.Windows.Forms.CheckBox();
+			this.chkEPSM = new System.Windows.Forms.CheckBox();
 			this.chkVrc6 = new System.Windows.Forms.CheckBox();
 			this.grpSquare1 = new System.Windows.Forms.GroupBox();
 			this.ctrlSquareInfo1 = new Mesen.GUI.Debugger.Controls.ctrlSquareInfo();
@@ -119,7 +119,7 @@
 			this.tableLayoutPanel2.Controls.Add(this.chkVrc7, 2, 1);
 			this.tableLayoutPanel2.Controls.Add(this.chkDmc, 0, 4);
 			this.tableLayoutPanel2.Controls.Add(this.chkSunsoft, 1, 3);
-			this.tableLayoutPanel2.Controls.Add(this.chkEPSG, 1, 4);
+			this.tableLayoutPanel2.Controls.Add(this.chkEPSM, 1, 4);
 			this.tableLayoutPanel2.Controls.Add(this.chkVrc6, 2, 0);
 			this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
 			this.tableLayoutPanel2.Location = new System.Drawing.Point(3, 16);
@@ -273,19 +273,19 @@
 			this.chkSunsoft.UseVisualStyleBackColor = true;
 			this.chkSunsoft.CheckedChanged += new System.EventHandler(this.chkSoundChannel_CheckedChanged);
 			// 
-			// chkEPSG
+			// chkEPSM
 			// 
-			this.chkEPSG.AutoSize = true;
-			this.chkEPSG.Checked = true;
-			this.chkEPSG.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.chkEPSG.Location = new System.Drawing.Point(99, 80);
-			this.chkEPSG.Margin = new System.Windows.Forms.Padding(3, 0, 3, 3);
-			this.chkEPSG.Name = "chkEPSG";
-			this.chkEPSG.Size = new System.Drawing.Size(78, 17);
-			this.chkEPSG.TabIndex = 10;
-			this.chkEPSG.Text = "EPSG";
-			this.chkEPSG.UseVisualStyleBackColor = true;
-			this.chkEPSG.CheckedChanged += new System.EventHandler(this.chkSoundChannel_CheckedChanged);
+			this.chkEPSM.AutoSize = true;
+			this.chkEPSM.Checked = true;
+			this.chkEPSM.CheckState = System.Windows.Forms.CheckState.Checked;
+			this.chkEPSM.Location = new System.Drawing.Point(99, 80);
+			this.chkEPSM.Margin = new System.Windows.Forms.Padding(3, 0, 3, 3);
+			this.chkEPSM.Name = "chkEPSM";
+			this.chkEPSM.Size = new System.Drawing.Size(78, 17);
+			this.chkEPSM.TabIndex = 10;
+			this.chkEPSM.Text = "EPSM";
+			this.chkEPSM.UseVisualStyleBackColor = true;
+			this.chkEPSM.CheckedChanged += new System.EventHandler(this.chkSoundChannel_CheckedChanged);
 			// 
 			// chkVrc6
 			// 
@@ -475,6 +475,6 @@
 		private System.Windows.Forms.CheckBox chkVrc7;
 		private System.Windows.Forms.CheckBox chkVrc6;
 		private System.Windows.Forms.CheckBox chkSunsoft;
-		private System.Windows.Forms.CheckBox chkEPSG;
+		private System.Windows.Forms.CheckBox chkEPSM;
 	}
 }

--- a/GUI.NET/Debugger/frmApuViewer.cs
+++ b/GUI.NET/Debugger/frmApuViewer.cs
@@ -68,8 +68,8 @@ namespace Mesen.GUI.Debugger
 			InteropEmu.SetChannelVolume(AudioChannel.VRC7, chkVrc7.Checked ? 1 : 0);
 			InteropEmu.SetChannelVolume(AudioChannel.MMC5, chkMmc5.Checked ? 1 : 0);
 			InteropEmu.SetChannelVolume(AudioChannel.Sunsoft5B, chkSunsoft.Checked ? 1 : 0);
-			InteropEmu.SetChannelVolume(AudioChannel.EPSG_L, chkEPSG.Checked ? AudioInfo.ConvertVolume(audioInfo.EPSGVolume_L) : 0);
-			InteropEmu.SetChannelVolume(AudioChannel.EPSG_R, chkEPSG.Checked ? AudioInfo.ConvertVolume(audioInfo.EPSGVolume_R) : 0);
+			InteropEmu.SetChannelVolume(AudioChannel.EPSM_L, chkEPSM.Checked ? AudioInfo.ConvertVolume(audioInfo.EPSMVolume_L) : 0);
+			InteropEmu.SetChannelVolume(AudioChannel.EPSM_R, chkEPSM.Checked ? AudioInfo.ConvertVolume(audioInfo.EPSMVolume_R) : 0);
 	  }
 	}
 }

--- a/GUI.NET/Forms/Config/frmAudioConfig.Designer.cs
+++ b/GUI.NET/Forms/Config/frmAudioConfig.Designer.cs
@@ -43,12 +43,12 @@ namespace Mesen.GUI.Forms.Config
             this.trkVrc7Vol = new Mesen.GUI.Controls.ctrlTrackbar();
             this.trkNamco163Vol = new Mesen.GUI.Controls.ctrlTrackbar();
             this.trkSunsoft5b = new Mesen.GUI.Controls.ctrlTrackbar();
-            this.trkEPSGVol_L = new Mesen.GUI.Controls.ctrlTrackbar();
-            this.trkEPSGVol_R = new Mesen.GUI.Controls.ctrlTrackbar();
+            this.trkEPSMVol_L = new Mesen.GUI.Controls.ctrlTrackbar();
+            this.trkEPSMVol_R = new Mesen.GUI.Controls.ctrlTrackbar();
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
             this.lblVolumeReductionSettings = new System.Windows.Forms.Label();
             this.chkEnableAudio = new System.Windows.Forms.CheckBox();
-            this.chkEnableEPSG = new System.Windows.Forms.CheckBox();
+            this.chkEnableEPSM = new System.Windows.Forms.CheckBox();
             this.lblSampleRate = new System.Windows.Forms.Label();
             this.lblAudioLatency = new System.Windows.Forms.Label();
             this.cboSampleRate = new System.Windows.Forms.ComboBox();
@@ -81,8 +81,8 @@ namespace Mesen.GUI.Forms.Config
             this.trkVrc7Pan = new Mesen.GUI.Controls.ctrlHorizontalTrackbar();
             this.trkNamcoPan = new Mesen.GUI.Controls.ctrlHorizontalTrackbar();
             this.trkSunsoftPan = new Mesen.GUI.Controls.ctrlHorizontalTrackbar();
-            this.trkEPSGPan_L = new Mesen.GUI.Controls.ctrlHorizontalTrackbar();
-            this.trkEPSGPan_R = new Mesen.GUI.Controls.ctrlHorizontalTrackbar();
+            this.trkEPSMPan_L = new Mesen.GUI.Controls.ctrlHorizontalTrackbar();
+            this.trkEPSMPan_R = new Mesen.GUI.Controls.ctrlHorizontalTrackbar();
             this.tpgEqualizer = new System.Windows.Forms.TabPage();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.chkEnableEqualizer = new System.Windows.Forms.CheckBox();
@@ -147,8 +147,8 @@ namespace Mesen.GUI.Forms.Config
             this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
             this.chkDisableDynamicSampleRate = new Mesen.GUI.Controls.ctrlRiskyOption();
             this.chkDisableNoiseModeFlag = new Mesen.GUI.Controls.ctrlRiskyOption();
-            this.nudEPSGClockFrequency = new Mesen.GUI.Controls.MesenNumericUpDown();
-            this.lblEPSGClockFrequency = new System.Windows.Forms.Label();
+            this.nudEPSMClockFrequency = new Mesen.GUI.Controls.MesenNumericUpDown();
+            this.lblEPSMClockFrequency = new System.Windows.Forms.Label();
             this.chkSilenceTriangleHighFreq = new System.Windows.Forms.CheckBox();
             this.chkSwapDutyCycles = new Mesen.GUI.Controls.ctrlRiskyOption();
             this.chkReduceDmcPopping = new System.Windows.Forms.CheckBox();
@@ -223,8 +223,8 @@ namespace Mesen.GUI.Forms.Config
             this.tableLayoutPanel1.Controls.Add(this.trkVrc7Vol, 3, 1);
             this.tableLayoutPanel1.Controls.Add(this.trkNamco163Vol, 4, 1);
             this.tableLayoutPanel1.Controls.Add(this.trkSunsoft5b, 6, 0);
-            this.tableLayoutPanel1.Controls.Add(this.trkEPSGVol_L, 5, 1);
-            this.tableLayoutPanel1.Controls.Add(this.trkEPSGVol_R, 6, 1);
+            this.tableLayoutPanel1.Controls.Add(this.trkEPSMVol_L, 5, 1);
+            this.tableLayoutPanel1.Controls.Add(this.trkEPSMVol_R, 6, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(3, 16);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
@@ -415,35 +415,35 @@ namespace Mesen.GUI.Forms.Config
             this.trkSunsoft5b.Text = "Sunsoft";
             this.trkSunsoft5b.Value = 50;
             // 
-            // trkEPSGVol_L
+            // trkEPSMVol_L
             // 
-            this.trkEPSGVol_L.Anchor = System.Windows.Forms.AnchorStyles.Top;
-            this.trkEPSGVol_L.Location = new System.Drawing.Point(364, 160);
-            this.trkEPSGVol_L.Margin = new System.Windows.Forms.Padding(0);
-            this.trkEPSGVol_L.Maximum = 100;
-            this.trkEPSGVol_L.MaximumSize = new System.Drawing.Size(63, 160);
-            this.trkEPSGVol_L.Minimum = 0;
-            this.trkEPSGVol_L.MinimumSize = new System.Drawing.Size(63, 160);
-            this.trkEPSGVol_L.Name = "trkEPSGVol_L";
-            this.trkEPSGVol_L.Size = new System.Drawing.Size(63, 160);
-            this.trkEPSGVol_L.TabIndex = 22;
-            this.trkEPSGVol_L.Text = "EPSG Left";
-            this.trkEPSGVol_L.Value = 100;
+            this.trkEPSMVol_L.Anchor = System.Windows.Forms.AnchorStyles.Top;
+            this.trkEPSMVol_L.Location = new System.Drawing.Point(364, 160);
+            this.trkEPSMVol_L.Margin = new System.Windows.Forms.Padding(0);
+            this.trkEPSMVol_L.Maximum = 100;
+            this.trkEPSMVol_L.MaximumSize = new System.Drawing.Size(63, 160);
+            this.trkEPSMVol_L.Minimum = 0;
+            this.trkEPSMVol_L.MinimumSize = new System.Drawing.Size(63, 160);
+            this.trkEPSMVol_L.Name = "trkEPSMVol_L";
+            this.trkEPSMVol_L.Size = new System.Drawing.Size(63, 160);
+            this.trkEPSMVol_L.TabIndex = 22;
+            this.trkEPSMVol_L.Text = "EPSM Left";
+            this.trkEPSMVol_L.Value = 100;
             // 
-            // trkEPSGVol_R
+            // trkEPSMVol_R
             // 
-            this.trkEPSGVol_R.Anchor = System.Windows.Forms.AnchorStyles.Top;
-            this.trkEPSGVol_R.Location = new System.Drawing.Point(432, 160);
-            this.trkEPSGVol_R.Margin = new System.Windows.Forms.Padding(0);
-            this.trkEPSGVol_R.Maximum = 100;
-            this.trkEPSGVol_R.MaximumSize = new System.Drawing.Size(63, 160);
-            this.trkEPSGVol_R.Minimum = 0;
-            this.trkEPSGVol_R.MinimumSize = new System.Drawing.Size(63, 160);
-            this.trkEPSGVol_R.Name = "trkEPSGVol_R";
-            this.trkEPSGVol_R.Size = new System.Drawing.Size(63, 160);
-            this.trkEPSGVol_R.TabIndex = 22;
-            this.trkEPSGVol_R.Text = "EPSG Right";
-            this.trkEPSGVol_R.Value = 100;
+            this.trkEPSMVol_R.Anchor = System.Windows.Forms.AnchorStyles.Top;
+            this.trkEPSMVol_R.Location = new System.Drawing.Point(432, 160);
+            this.trkEPSMVol_R.Margin = new System.Windows.Forms.Padding(0);
+            this.trkEPSMVol_R.Maximum = 100;
+            this.trkEPSMVol_R.MaximumSize = new System.Drawing.Size(63, 160);
+            this.trkEPSMVol_R.Minimum = 0;
+            this.trkEPSMVol_R.MinimumSize = new System.Drawing.Size(63, 160);
+            this.trkEPSMVol_R.Name = "trkEPSMVol_R";
+            this.trkEPSMVol_R.Size = new System.Drawing.Size(63, 160);
+            this.trkEPSMVol_R.TabIndex = 22;
+            this.trkEPSMVol_R.Text = "EPSM Right";
+            this.trkEPSMVol_R.Value = 100;
             // 
             // tableLayoutPanel2
             // 
@@ -451,7 +451,7 @@ namespace Mesen.GUI.Forms.Config
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanel2.Controls.Add(this.chkEnableAudio, 0, 0);
-            this.tableLayoutPanel2.Controls.Add(this.chkEnableEPSG, 0, 0);
+            this.tableLayoutPanel2.Controls.Add(this.chkEnableEPSM, 0, 0);
             this.tableLayoutPanel2.Controls.Add(this.lblSampleRate, 0, 2);
             this.tableLayoutPanel2.Controls.Add(this.lblAudioLatency, 0, 3);
             this.tableLayoutPanel2.Controls.Add(this.cboSampleRate, 1, 2);
@@ -502,17 +502,17 @@ namespace Mesen.GUI.Forms.Config
             this.chkEnableAudio.Text = "Enable Audio";
             this.chkEnableAudio.UseVisualStyleBackColor = true;
             // 
-            // chkEnableEPSG
+            // chkEnableEPSM
             // 
-            this.chkEnableEPSG.AutoSize = true;
-            this.tableLayoutPanel2.SetColumnSpan(this.chkEnableEPSG, 2);
-            this.chkEnableEPSG.Location = new System.Drawing.Point(6, 6);
-            this.chkEnableEPSG.Margin = new System.Windows.Forms.Padding(6, 6, 6, 3);
-            this.chkEnableEPSG.Name = "chkEnableEPSG";
-            this.chkEnableEPSG.Size = new System.Drawing.Size(91, 17);
-            this.chkEnableEPSG.TabIndex = 3;
-            this.chkEnableEPSG.Text = "Enable EPSG";
-            this.chkEnableEPSG.UseVisualStyleBackColor = true;
+            this.chkEnableEPSM.AutoSize = true;
+            this.tableLayoutPanel2.SetColumnSpan(this.chkEnableEPSM, 2);
+            this.chkEnableEPSM.Location = new System.Drawing.Point(6, 6);
+            this.chkEnableEPSM.Margin = new System.Windows.Forms.Padding(6, 6, 6, 3);
+            this.chkEnableEPSM.Name = "chkEnableEPSM";
+            this.chkEnableEPSM.Size = new System.Drawing.Size(91, 17);
+            this.chkEnableEPSM.TabIndex = 3;
+            this.chkEnableEPSM.Text = "Enable EPSM";
+            this.chkEnableEPSM.UseVisualStyleBackColor = true;
             // 
             // lblSampleRate
             // 
@@ -802,8 +802,8 @@ namespace Mesen.GUI.Forms.Config
             this.tableLayoutPanel6.Controls.Add(this.trkVrc7Pan, 1, 3);
             this.tableLayoutPanel6.Controls.Add(this.trkNamcoPan, 1, 4);
             this.tableLayoutPanel6.Controls.Add(this.trkSunsoftPan, 0, 6);
-            this.tableLayoutPanel6.Controls.Add(this.trkEPSGPan_L, 0, 5);
-            this.tableLayoutPanel6.Controls.Add(this.trkEPSGPan_R, 1, 5);
+            this.tableLayoutPanel6.Controls.Add(this.trkEPSMPan_L, 0, 5);
+            this.tableLayoutPanel6.Controls.Add(this.trkEPSMPan_R, 1, 5);
             this.tableLayoutPanel6.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel6.Location = new System.Drawing.Point(3, 3);
             this.tableLayoutPanel6.Name = "tableLayoutPanel6";
@@ -984,35 +984,35 @@ namespace Mesen.GUI.Forms.Config
             this.trkSunsoftPan.Text = "Sunsoft";
             this.trkSunsoftPan.Value = 0;
             // 
-            // trkEPSGPan_L
+            // trkEPSMPan_L
             // 
-            this.trkEPSGPan_L.Anchor = System.Windows.Forms.AnchorStyles.Top;
-            this.trkEPSGPan_L.Location = new System.Drawing.Point(12, 275);
-            this.trkEPSGPan_L.Margin = new System.Windows.Forms.Padding(0);
-            this.trkEPSGPan_L.Maximum = 100;
-            this.trkEPSGPan_L.MaximumSize = new System.Drawing.Size(63, 160);
-            this.trkEPSGPan_L.Minimum = -100;
-            this.trkEPSGPan_L.MinimumSize = new System.Drawing.Size(206, 55);
-            this.trkEPSGPan_L.Name = "trkEPSGPan_L";
-            this.trkEPSGPan_L.Size = new System.Drawing.Size(206, 55);
-            this.trkEPSGPan_L.TabIndex = 22;
-            this.trkEPSGPan_L.Text = "EPSG Left";
-            this.trkEPSGPan_L.Value = -100;
+            this.trkEPSMPan_L.Anchor = System.Windows.Forms.AnchorStyles.Top;
+            this.trkEPSMPan_L.Location = new System.Drawing.Point(12, 275);
+            this.trkEPSMPan_L.Margin = new System.Windows.Forms.Padding(0);
+            this.trkEPSMPan_L.Maximum = 100;
+            this.trkEPSMPan_L.MaximumSize = new System.Drawing.Size(63, 160);
+            this.trkEPSMPan_L.Minimum = -100;
+            this.trkEPSMPan_L.MinimumSize = new System.Drawing.Size(206, 55);
+            this.trkEPSMPan_L.Name = "trkEPSMPan_L";
+            this.trkEPSMPan_L.Size = new System.Drawing.Size(206, 55);
+            this.trkEPSMPan_L.TabIndex = 22;
+            this.trkEPSMPan_L.Text = "EPSM Left";
+            this.trkEPSMPan_L.Value = -100;
             // 
-            // trkEPSGPan_R
+            // trkEPSMPan_R
             // 
-            this.trkEPSGPan_R.Anchor = System.Windows.Forms.AnchorStyles.Top;
-            this.trkEPSGPan_R.Location = new System.Drawing.Point(244, 275);
-            this.trkEPSGPan_R.Margin = new System.Windows.Forms.Padding(0);
-            this.trkEPSGPan_R.Maximum = 100;
-            this.trkEPSGPan_R.MaximumSize = new System.Drawing.Size(63, 160);
-            this.trkEPSGPan_R.Minimum = -100;
-            this.trkEPSGPan_R.MinimumSize = new System.Drawing.Size(206, 55);
-            this.trkEPSGPan_R.Name = "trkEPSGPan_R";
-            this.trkEPSGPan_R.Size = new System.Drawing.Size(206, 55);
-            this.trkEPSGPan_R.TabIndex = 22;
-            this.trkEPSGPan_R.Text = "EPSG Right";
-            this.trkEPSGPan_R.Value = 100;
+            this.trkEPSMPan_R.Anchor = System.Windows.Forms.AnchorStyles.Top;
+            this.trkEPSMPan_R.Location = new System.Drawing.Point(244, 275);
+            this.trkEPSMPan_R.Margin = new System.Windows.Forms.Padding(0);
+            this.trkEPSMPan_R.Maximum = 100;
+            this.trkEPSMPan_R.MaximumSize = new System.Drawing.Size(63, 160);
+            this.trkEPSMPan_R.Minimum = -100;
+            this.trkEPSMPan_R.MinimumSize = new System.Drawing.Size(206, 55);
+            this.trkEPSMPan_R.Name = "trkEPSMPan_R";
+            this.trkEPSMPan_R.Size = new System.Drawing.Size(206, 55);
+            this.trkEPSMPan_R.TabIndex = 22;
+            this.trkEPSMPan_R.Text = "EPSM Right";
+            this.trkEPSMPan_R.Value = 100;
             // 
             // tpgEqualizer
             // 
@@ -1988,8 +1988,8 @@ namespace Mesen.GUI.Forms.Config
             this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel3.Controls.Add(this.chkDisableDynamicSampleRate, 0, 2);
             this.tableLayoutPanel3.Controls.Add(this.chkDisableNoiseModeFlag, 0, 4);
-            this.tableLayoutPanel3.Controls.Add(this.nudEPSGClockFrequency, 0, 5);
-            this.tableLayoutPanel3.Controls.Add(this.lblEPSGClockFrequency, 0, 5);
+            this.tableLayoutPanel3.Controls.Add(this.nudEPSMClockFrequency, 0, 5);
+            this.tableLayoutPanel3.Controls.Add(this.lblEPSMClockFrequency, 0, 5);
             this.tableLayoutPanel3.Controls.Add(this.chkSilenceTriangleHighFreq, 0, 0);
             this.tableLayoutPanel3.Controls.Add(this.chkSwapDutyCycles, 0, 3);
             this.tableLayoutPanel3.Controls.Add(this.chkReduceDmcPopping, 0, 1);
@@ -2027,47 +2027,47 @@ namespace Mesen.GUI.Forms.Config
             this.chkDisableNoiseModeFlag.TabIndex = 3;
             this.chkDisableNoiseModeFlag.Text = "Disable noise channel mode flag";
             // 
-            // nudEPSGClockFrequency
+            // nudEPSMClockFrequency
             // 
-            this.nudEPSGClockFrequency.DecimalPlaces = 0;
-            this.nudEPSGClockFrequency.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.nudEPSGClockFrequency.Increment = new decimal(new int[] {
+            this.nudEPSMClockFrequency.DecimalPlaces = 0;
+            this.nudEPSMClockFrequency.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.nudEPSMClockFrequency.Increment = new decimal(new int[] {
             100000,
             0,
             0,
             0});
-            this.nudEPSGClockFrequency.IsHex = false;
-            this.nudEPSGClockFrequency.Location = new System.Drawing.Point(3, 147);
-            this.nudEPSGClockFrequency.Maximum = new decimal(new int[] {
+            this.nudEPSMClockFrequency.IsHex = false;
+            this.nudEPSMClockFrequency.Location = new System.Drawing.Point(3, 147);
+            this.nudEPSMClockFrequency.Maximum = new decimal(new int[] {
             32000000,
             0,
             0,
             0});
-            this.nudEPSGClockFrequency.MaximumSize = new System.Drawing.Size(10000, 20);
-            this.nudEPSGClockFrequency.Minimum = new decimal(new int[] {
+            this.nudEPSMClockFrequency.MaximumSize = new System.Drawing.Size(10000, 20);
+            this.nudEPSMClockFrequency.Minimum = new decimal(new int[] {
             10000,
             0,
             0,
             0});
-            this.nudEPSGClockFrequency.MinimumSize = new System.Drawing.Size(200, 21);
-            this.nudEPSGClockFrequency.Name = "nudEPSGClockFrequency";
-            this.nudEPSGClockFrequency.Size = new System.Drawing.Size(457, 21);
-            this.nudEPSGClockFrequency.TabIndex = 3;
-            this.nudEPSGClockFrequency.Value = new decimal(new int[] {
+            this.nudEPSMClockFrequency.MinimumSize = new System.Drawing.Size(200, 21);
+            this.nudEPSMClockFrequency.Name = "nudEPSMClockFrequency";
+            this.nudEPSMClockFrequency.Size = new System.Drawing.Size(457, 21);
+            this.nudEPSMClockFrequency.TabIndex = 3;
+            this.nudEPSMClockFrequency.Value = new decimal(new int[] {
             10000,
             0,
             0,
             0});
             // 
-            // lblEPSGClockFrequency
+            // lblEPSMClockFrequency
             // 
-            this.lblEPSGClockFrequency.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.lblEPSGClockFrequency.AutoSize = true;
-            this.lblEPSGClockFrequency.Location = new System.Drawing.Point(3, 125);
-            this.lblEPSGClockFrequency.Name = "lblEPSGClockFrequency";
-            this.lblEPSGClockFrequency.Size = new System.Drawing.Size(228, 13);
-            this.lblEPSGClockFrequency.TabIndex = 3;
-            this.lblEPSGClockFrequency.Text = "EPSG Clock Frequency (default is 3579545Hz)";
+            this.lblEPSMClockFrequency.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.lblEPSMClockFrequency.AutoSize = true;
+            this.lblEPSMClockFrequency.Location = new System.Drawing.Point(3, 125);
+            this.lblEPSMClockFrequency.Name = "lblEPSMClockFrequency";
+            this.lblEPSMClockFrequency.Size = new System.Drawing.Size(228, 13);
+            this.lblEPSMClockFrequency.TabIndex = 3;
+            this.lblEPSMClockFrequency.Text = "EPSM Clock Frequency (default is 3579545Hz)";
             // 
             // chkSilenceTriangleHighFreq
             // 
@@ -2166,7 +2166,7 @@ namespace Mesen.GUI.Forms.Config
 		private System.Windows.Forms.GroupBox grpVolume;
 		private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
 		private System.Windows.Forms.CheckBox chkEnableAudio;
-		private System.Windows.Forms.CheckBox chkEnableEPSG;
+		private System.Windows.Forms.CheckBox chkEnableEPSM;
 		private System.Windows.Forms.Label lblAudioLatency;
 		private MesenNumericUpDown nudLatency;
 		private System.Windows.Forms.Label lblLatencyMs;
@@ -2188,8 +2188,8 @@ namespace Mesen.GUI.Forms.Config
 		private Controls.ctrlTrackbar trkVrc7Vol;
 		private Controls.ctrlTrackbar trkNamco163Vol;
 		private Controls.ctrlTrackbar trkSunsoft5b;
-		private Controls.ctrlTrackbar trkEPSGVol_L;
-		private Controls.ctrlTrackbar trkEPSGVol_R;
+		private Controls.ctrlTrackbar trkEPSMVol_L;
+		private Controls.ctrlTrackbar trkEPSMVol_R;
 	  private System.Windows.Forms.TabControl tabMain;
 		private System.Windows.Forms.TabPage tpgGeneral;
 		private System.Windows.Forms.TabPage tpgVolume;
@@ -2230,8 +2230,8 @@ namespace Mesen.GUI.Forms.Config
 		private Controls.ctrlHorizontalTrackbar trkVrc7Pan;
 		private Controls.ctrlHorizontalTrackbar trkNamcoPan;
 		private Controls.ctrlHorizontalTrackbar trkSunsoftPan;
-		private Controls.ctrlHorizontalTrackbar trkEPSGPan_L;
-		private Controls.ctrlHorizontalTrackbar trkEPSGPan_R;
+		private Controls.ctrlHorizontalTrackbar trkEPSMPan_L;
+		private Controls.ctrlHorizontalTrackbar trkEPSMPan_R;
 		private Controls.ctrlHorizontalTrackbar trkSquare1Pan;
 		private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel5;
 		private System.Windows.Forms.CheckBox chkCrossFeedEnabled;
@@ -2239,8 +2239,8 @@ namespace Mesen.GUI.Forms.Config
 		private System.Windows.Forms.Label lblCrossFeedRatio;
 		private Controls.ctrlHorizontalTrackbar trkTrianglePan;
 		private ctrlRiskyOption chkDisableNoiseModeFlag;
-		private MesenNumericUpDown nudEPSGClockFrequency;
-		private System.Windows.Forms.Label lblEPSGClockFrequency;
+		private MesenNumericUpDown nudEPSMClockFrequency;
+		private System.Windows.Forms.Label lblEPSMClockFrequency;
 		private System.Windows.Forms.TabPage tpgEqualizer;
 		private System.Windows.Forms.TableLayoutPanel tlpEqualizer;
 		private ctrlTrackbar trkBand6Gain;

--- a/GUI.NET/Forms/Config/frmAudioConfig.cs
+++ b/GUI.NET/Forms/Config/frmAudioConfig.cs
@@ -31,7 +31,7 @@ namespace Mesen.GUI.Forms.Config
 			cboAudioDevice.Items.AddRange(InteropEmu.GetAudioDevices().ToArray());
 
 			AddBinding("EnableAudio", chkEnableAudio);
-			AddBinding("EnableEPSG", chkEnableEPSG);
+			AddBinding("EnableEPSM", chkEnableEPSM);
 			AddBinding("MasterVolume", trkMaster);
 			AddBinding("Square1Volume", trkSquare1Vol);
 			AddBinding("Square2Volume", trkSquare2Vol);
@@ -44,8 +44,8 @@ namespace Mesen.GUI.Forms.Config
 			AddBinding("Vrc7Volume", trkVrc7Vol);
 			AddBinding("Namco163Volume", trkNamco163Vol);
 			AddBinding("Sunsoft5bVolume", trkSunsoft5b);
-			AddBinding("EPSGVolume_L", trkEPSGVol_L);
-			AddBinding("EPSGVolume_R", trkEPSGVol_R);
+			AddBinding("EPSMVolume_L", trkEPSMVol_L);
+			AddBinding("EPSMVolume_R", trkEPSMVol_R);
 
 			AddBinding("Square1Panning", trkSquare1Pan);
 			AddBinding("Square2Panning", trkSquare2Pan);
@@ -58,10 +58,10 @@ namespace Mesen.GUI.Forms.Config
 			AddBinding("Vrc7Panning", trkVrc7Pan);
 			AddBinding("Namco163Panning", trkNamcoPan);
 			AddBinding("Sunsoft5bPanning", trkSunsoftPan);
-			AddBinding("EPSGPanning_L", trkEPSGPan_L);
-			AddBinding("EPSGPanning_R", trkEPSGPan_R);
+			AddBinding("EPSMPanning_L", trkEPSMPan_L);
+			AddBinding("EPSMPanning_R", trkEPSMPan_R);
 
-			AddBinding("EPSGClockFrequency", nudEPSGClockFrequency);
+			AddBinding("EPSMClockFrequency", nudEPSMClockFrequency);
 
 			AddBinding("AudioLatency", nudLatency);
 			AddBinding("SampleRate", cboSampleRate);

--- a/GUI.NET/InteropEmu.cs
+++ b/GUI.NET/InteropEmu.cs
@@ -208,7 +208,7 @@ namespace Mesen.GUI
 		[DllImport(DLLPath)] public static extern void SetBandGain(int band, double gain);
 		[DllImport(DLLPath)] public static extern void SetSampleRate(UInt32 sampleRate);
 		[DllImport(DLLPath)] public static extern void SetAudioLatency(UInt32 msLatency);
-		[DllImport(DLLPath)] public static extern void SetEPSGClockFrequency(UInt32 clockFrequency);
+		[DllImport(DLLPath)] public static extern void SetEPSMClockFrequency(UInt32 clockFrequency);
 		[DllImport(DLLPath)] public static extern void SetAudioFilterSettings(AudioFilterSettings settings);
 		[DllImport(DLLPath)] public static extern void SetRunAheadFrames(UInt32 frameCount);
 
@@ -2300,8 +2300,8 @@ namespace Mesen.GUI
 		VRC7 = 8,
 		Namco163 = 9,
 		Sunsoft5B = 10,
-		EPSG_L = 11,
-		EPSG_R= 12
+		EPSM_L = 11,
+		EPSM_R= 12
    }
 
 	public enum EqualizerFilterType

--- a/InteropDLL/ConsoleWrapper.cpp
+++ b/InteropDLL/ConsoleWrapper.cpp
@@ -633,7 +633,7 @@ namespace InteropEmu {
 		DllExport void __stdcall SetMasterVolume(double volume, double volumeReduction, ConsoleId consoleId) { GetConsoleById(consoleId)->GetSettings()->SetMasterVolume(volume, volumeReduction); }
 		DllExport void __stdcall SetSampleRate(uint32_t sampleRate) { _settings->SetSampleRate(sampleRate); }
 		DllExport void __stdcall SetAudioLatency(uint32_t msLatency) { _settings->SetAudioLatency(msLatency); }
-		DllExport void __stdcall SetEPSGClockFrequency(uint32_t clockFrequency) { _settings->SetEPSGClockFrequency(clockFrequency); }
+		DllExport void __stdcall SetEPSMClockFrequency(uint32_t clockFrequency) { _settings->SetEPSMClockFrequency(clockFrequency); }
 		DllExport void __stdcall SetAudioFilterSettings(AudioFilterSettings settings) { _settings->SetAudioFilterSettings(settings); }
 		DllExport void __stdcall SetRunAheadFrames(uint32_t frameCount) { _settings->SetRunAheadFrames(frameCount); }
 


### PR DESCRIPTION
Hardware naming changed when going from prototyping stage.
Added an addressing mode that's easily used and shouldn't conflict with any mappers.
Changed the NSF header bit from bit 6 to bit 7, bit 6 is already used for VT02+