### PR TITLE
Audio interference hotfix

### DIFF
--- a/Core/Console.cpp
+++ b/Core/Console.cpp
@@ -473,10 +473,10 @@ void Console::ProcessCpuClock()
 
 void Console::ProcessInterferenceAudio()
 {
-	_InvA13 = _ppu->_A13pinLow;
+	_InvA13 = (_ppu->_A13pinLow == 1) ? 0 : 1; // invert relative to 2A03
 
 	_controlManager->GetInvOE1(_controlManager->_address);
-	_InvOE1 = _controlManager->_OE1pinLow;
+	_InvOE1 = (_controlManager->_OE1pinLow == 1) ? 0 : 1; // invert relative to 2A03
 
 	if (_controlManager->_strobed == true)
 		_controlManager->_strobed = false;

--- a/Core/SoundMixer.cpp
+++ b/Core/SoundMixer.cpp
@@ -277,8 +277,8 @@ int16_t SoundMixer::GetOutputVolume(bool forRightChannel)
 #endif
 		GetChannelOutput(AudioChannel::EPSM_L, forRightChannel) * 4 +
 		GetChannelOutput(AudioChannel::EPSM_R, forRightChannel) * 4 +
-		GetChannelOutput(AudioChannel::InvA13, forRightChannel) * 500 +
-		GetChannelOutput(AudioChannel::InvOE1, forRightChannel) * 500
+		GetChannelOutput(AudioChannel::InvA13, forRightChannel) * 20 +
+		GetChannelOutput(AudioChannel::InvOE1, forRightChannel) * 1000
 	);
 }
 


### PR DESCRIPTION
This hotfix aims to do the following:
#### Adjust the mixing of the two interference channels in reference to 2A03 output.
- I used my own RF Famicom for reference, motherboard revision HVC-CPU-07 running an Everdrive N8 Pro.
Note that other consoles such as the NES frontloader may have different levels, so the volume level sliders may provide compensation for the mixing.
- [Reference audio](https://mega.nz/file/mmBA1ZCD#qgM_K9Eg5FbXt-kGbsQUmB315Kg8S0qTHyg_HdKjT50)
- [Reference audio compared to Mesen output ](https://mega.nz/file/XrRymLgT#M5rF5eiWalFzgxW1hFL05m2B58ujk3KGO-VeMVI1zDE) (left is hardware, right is Mesen)

#### Add more interference channels
- Though /A13 and /OE1 are the major contributors of the interference buzz, there might be other signals that I've neglected to look into, one of which may be $4016 D0 and D1.