### PR TITLE
Fix for settings not saving under mono 6.12

### DIFF
--- a/GUI.NET/Forms/BaseConfigForm.cs
+++ b/GUI.NET/Forms/BaseConfigForm.cs
@@ -148,11 +148,13 @@ namespace Mesen.GUI.Forms
 
 		private void btnOK_Click(object sender, EventArgs e)
 		{
+			this.DialogResult = ((Button)sender).DialogResult;
 			this.Close();
 		}
 
 		private void btnCancel_Click(object sender, EventArgs e)
 		{
+			this.DialogResult = ((Button)sender).DialogResult;
 			this.Close();
 		}
 	}


### PR DESCRIPTION
This fix addresses issues #30 and #4. This should not cause any issues under Windows but has not been tested there.